### PR TITLE
Merge back into reysic’s project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "10.0.102"
 
       - name: Setup Git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,12 @@ name: Release
 
 on:
   push:
-    tags: [v*]
+    tags:
+      - "v*"
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   release:
@@ -11,15 +15,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
 
       - name: Setup Git
         run: |
           git config --global url."https://user:${{ secrets.GITHUB_TOKEN }}@github".insteadOf https://github
           git config --global user.name github-actions
-          git config --global user.email github-actions@github.com          
+          git config --global user.email github-actions@github.com
 
       - name: Run release script
         shell: PowerShell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# AGENTS.md — Azure Key Vault Explorer
+
+This file provides context for AI coding agents working in this repository.
+
+## What this project is
+
+Azure Key Vault Explorer is a Windows desktop application (.NET 10 / WinForms) for browsing,
+editing, and managing secrets, keys, and certificates stored in Azure Key Vault. It supports
+ClickOnce deployment so end users install and auto-update via a hosted manifest URL.
+
+This repository is a fork of [reysic/AzureKeyVaultExplorer](https://github.com/reysic/AzureKeyVaultExplorer),
+which originated from [microsoft/AzureKeyVaultExplorer](https://github.com/microsoft/AzureKeyVaultExplorer).
+Changes developed here are intended to be contributed back upstream via a PR to reysic's fork.
+
+## Tech stack
+
+| Layer | Technology |
+|---|---|
+| UI | Windows Forms (.NET 10) |
+| Auth | Microsoft.Identity.Client (MSAL v4) — browser-based OAuth |
+| Azure SDK | Microsoft.Azure.Management.KeyVault (ARM), Microsoft.Azure.KeyVault (data plane) |
+| Publishing | ClickOnce via MSBuild `/target:publish` with `ClickOnceProfile.pubxml` |
+| CI | GitHub Actions (`.github/workflows/release.yml`), triggered by `v*` tags |
+
+## Repository layout
+
+```
+AzureKeyVaultExplorer.sln       Solution file
+Vault/
+  Explorer/                     Main WinForms app (VaultExplorer.csproj)
+    Common/                     Helpers: ActivationUri, Utils, UxOperation
+    Config/                     VaultConfigurationManager + JSON config templates
+    Controls/                   ListViews, custom WinForms controls
+    Dialogs/
+      Subscriptions/            SubscriptionsManagerDialog — vault picker via ARM
+      Secrets/                  SecretDialog
+      Certificates/             CertificateDialog
+      Settings/                 SettingsDialog
+    Model/                      Domain objects: PropObjects, ContentTypes, Tags, Aliases
+    Globals.cs                  All global URL constants (GitHub, ClickOnce install URL)
+    MainForm.cs                 Main window; hosts vault dropdown and secret list
+    Program.cs                  Entry point; handles ClickOnce activation URI
+  Library/                      Vault access abstractions (VaultAccess*, VaultConfig, etc.)
+  Core/                         Utilities shared across Library and Explorer
+  ClearClipboard/               Companion exe to clear clipboard after copy-secret
+  Build/                        T4 templates and version props
+.github/workflows/release.yml  CI release workflow
+release.ps1                     Local / CI publish script (requires MSBuild 17.14+)
+release.md                      Step-by-step release instructions
+tag_and_push.ps1               Creates and pushes a `v*` tag to trigger release
+```
+
+## Key constants — always keep these pointing to reysic
+
+`Vault/Explorer/Globals.cs` holds every URL string the app uses at runtime:
+
+```csharp
+OnlineActivationUri  = "https://reysic.github.io/AzureKeyVaultExplorer/VaultExplorer.application"
+GitHubUrl            = "https://github.com/reysic/AzureKeyVaultExplorer"
+GitHubIssuesUrl      = "https://github.com/reysic/AzureKeyVaultExplorer/issues"
+ActivationUrl        = "https://reysic.github.io/AzureKeyVaultExplorer/VaultExplorer.application"
+```
+
+`Vault/Explorer/Properties/PublishProfiles/ClickOnceProfile.pubxml` holds the ClickOnce
+`InstallUrl`, `ErrorReportUrl`, and `SupportUrl` — these must also point to reysic.
+
+## How to build locally
+
+```
+dotnet build AzureKeyVaultExplorer.sln
+```
+
+Requirements: .NET 10 SDK (`dotnet --list-sdks` should show `10.x`).
+
+## How to publish (ClickOnce release)
+
+See `release.md`. Short version:
+
+1. Run `.\tag_and_push.ps1` — creates and pushes a `v*` tag.
+2. GitHub Actions runs `release.ps1` which publishes with MSBuild and pushes output to `gh-pages`.
+3. Users install / update from `https://reysic.github.io/AzureKeyVaultExplorer`.
+
+For local-only publish validation (no gh-pages push):
+```powershell
+.\release.ps1 -OnlyBuild
+```
+
+Requires: **Visual Studio 2022 17.14+** (MSBuild 17.14+ for .NET 10 ClickOnce).
+
+## Vault picker dialog (SubscriptionsManagerDialog)
+
+The "Pick vault from subscription..." flow in `MainForm.cs` opens
+`Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs`.
+
+Key behaviors to be aware of when editing it:
+
+- **Account → Tenant → Subscription → Vault** — cascading async selection.
+- `uxButtonOK` starts **disabled**; it is only enabled after `Vaults.GetAsync` succeeds in
+  `uxListViewVaults_SelectedIndexChanged`. A try-catch wraps this call — errors show a warning
+  MessageBox but leave the dialog open so the user can pick a different vault.
+- The onboarding prompt (no saved accounts) fires from the `Shown` event, not the constructor,
+  so the form is fully rendered before any MessageBox appears.
+- `MinimumSize` is set in the Designer to prevent the window from being resized so small that
+  the OK/Cancel buttons are clipped.
+
+## UxOperation pattern
+
+`Common/UxOperation.cs` is used with `using` to show progress while async work runs:
+
+```csharp
+using (var op = this.NewUxOperationWithProgress(controlsToDisable))
+{
+    // async work here; op.CancellationToken is available
+}
+```
+
+`Dispose()` re-enables controls, hides the progress bar, and resets the cursor.
+
+## Configuration files (user-editable)
+
+Located in the app's install folder or a user-specified "Root location":
+
+| File | Purpose |
+|---|---|
+| `Vaults.json` | Vault credential definitions |
+| `VaultAliases.json` | Named vault aliases shown in the main dropdown |
+| `SecretKinds.json` | Regex-validated secret types with tag schemas |
+| `CustomTags.json` | Tag definitions referenced by SecretKinds |
+
+## Known open items
+
+- Deprecated Azure SDK packages (Microsoft.Azure.KeyVault, Microsoft.Azure.Management.KeyVault,
+  Microsoft.IdentityModel.Clients.ActiveDirectory, etc.) — migration to Track 2 non-preview
+  packages is a pending backlog item.
+- PowerShell integration was removed (does not work with .NET 8+).
+
+## Coding conventions
+
+- Namespace prefix: `Microsoft.Vault.*`
+- `async void` is used only for WinForms event handlers; wrap async body in try-catch.
+- All user-visible strings are inline (no resource file abstraction needed for this tool).
+- Designer-generated code lives in `*.Designer.cs`; do not edit `.resx` binary sections manually.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Azure Key Vault Explorer - be productive when working with secrets!
 
-**[Click here to install the latest version (VaultExplorer.application)](https://alta01.github.io/AzureKeyVaultExplorer/VaultExplorer.application)**
+**[Click here to install the latest version (VaultExplorer.application)](https://reysic.github.io/AzureKeyVaultExplorer/VaultExplorer.application)**
 
 If the install link does not load yet, enable **GitHub Pages** in this fork (`Settings -> Pages`) and publish from the branch that contains this repository.
 
@@ -35,7 +35,7 @@ Contact: Submit issues/PRs on this repo
 * [Contributing](#contributing)
   * [TODOs](#todos)
 
-## Alta01 Updates (using Copilot)
+## Recent Updates
 
 * **Tenant selector and account flow improvements**
   * Sign in first, then select tenant from discovered tenants before loading subscriptions.
@@ -59,7 +59,7 @@ Contact: Submit issues/PRs on this repo
 
 * Best user experience for authentication, you will be prompted at most *once* to enter your credentials
 * All types of authentications are supported: Certificate, Secret and User based with 2FA (including PHX or GME)
-* One click activation, just run this: `https://alta01.github.io/AzureKeyVaultExplorer?vault://[ENTER HERE YOUR VAULT NAME]`
+* One click activation, just run this: `https://reysic.github.io/AzureKeyVaultExplorer?vault://[ENTER HERE YOUR VAULT NAME]`
 * Support single or dual vaults
 * Upload and download certificate (.pfx, .p12 and .cer) files
 * Import and export certificates to user or machine stores in just few clicks
@@ -90,7 +90,7 @@ Contact: Submit issues/PRs on this repo
 
 There are 4 ways how you can make Vault Explorer to work with your vaults:
 
-1. In case Vault Explorer is not installed on the box, you may just run: alta01.github.io/AzureKeyVaultExplorer?vault://[ENTER HERE YOUR VAULT NAME]`
+1. In case Vault Explorer is not installed on the box, you may just run: `reysic.github.io/AzureKeyVaultExplorer?vault://[ENTER HERE YOUR VAULT NAME]`
 2. In case Vault Explorer already installed on the box, you can just hit Win+R type `vault://[ENTER HERE YOUR VAULT NAME]` and hit Enter
     * Note: The above two methods do **NOT** allow for alternative account login  
 3. Run Vault Explorer, open vault combo box, select last item "Pick vault from subscription..."  
@@ -117,7 +117,7 @@ Just complete the below fairly easy manual steps *once*:
 * Enter - edit item
 * Ctrl + A - select all items
 * Ctrl + C - copy item value to clipboard for some time (configurable)
-* Ctrl + Shift + C - copy link to the selected item in the following format: `https://alta01.github.io/AzureKeyVaultExplorer?vault://vaultName/collection/itemName/version`
+* Ctrl + Shift + C - copy link to the selected item in the following format: `https://reysic.github.io/AzureKeyVaultExplorer?vault://vaultName/collection/itemName/version`
 * Ctrl + D - add item to favorites / remove item from favorites
 * Ctrl + E - edit item
 * Ctrl + F - find items
@@ -334,7 +334,7 @@ PRs are welcome!
 
 ### Publishing
 
-See [release.md](./release.md). Following that process triggers [Actions](https://github.com/alta01/AzureKeyVaultExplorer/actions), which run [release.ps1](https://github.com/alta01/AzureKeyVaultExplorer/blob/main/release.ps1).
+See [release.md](./release.md). Following that process triggers [Actions](https://github.com/reysic/AzureKeyVaultExplorer/actions), which run [release.ps1](https://github.com/reysic/AzureKeyVaultExplorer/blob/main/release.ps1).
 
 ### TODOs
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Azure Key Vault Explorer - be productive when working with secrets!
 
-**[Click here to install the latest version (https://alta01.github.io/AzureKeyVaultExplorer)](https://alta01.github.io/AzureKeyVaultExplorer)**
+**[Click here to install the latest version (VaultExplorer.application)](https://alta01.github.io/AzureKeyVaultExplorer/VaultExplorer.application)**
 
 If the install link does not load yet, enable **GitHub Pages** in this fork (`Settings -> Pages`) and publish from the branch that contains this repository.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # ![bigKey](./Screenshots/Key64x64.png) Azure Key Vault Explorer
 
-**NOTE: This is a fork of the original project located at [https://github.com/microsoft/AzureKeyVaultExplorer](https://github.com/microsoft/AzureKeyVaultExplorer). This fork is not maintained by, or affiliated with, Microsoft, and was created to allow for continued development of the tool by the community.**
+**NOTE: This repository is a fork of [reysic/AzureKeyVaultExplorer](https://github.com/reysic/AzureKeyVaultExplorer), which itself originated from [microsoft/AzureKeyVaultExplorer](https://github.com/microsoft/AzureKeyVaultExplorer). This fork is community-maintained and includes updates developed with GitHub Copilot assistance.**
 
 Azure Key Vault Explorer - be productive when working with secrets!
 
-**[Click here to install the latest version (https://reysic.github.io/AzureKeyVaultExplorer)](https://reysic.github.io/AzureKeyVaultExplorer)**
+**[Click here to install the latest version (https://alta01.github.io/AzureKeyVaultExplorer)](https://alta01.github.io/AzureKeyVaultExplorer)**
+
+If the install link does not load yet, enable **GitHub Pages** in this fork (`Settings -> Pages`) and publish from the branch that contains this repository.
 
 Original Authors: Eli Zeitlin, Gokhan Ozhan, Anna Zeitlin  
 Current Authors: [reysic](https://github.com/reysic), [softworkz](https://github.com/softworkz)  
@@ -33,11 +35,31 @@ Contact: Submit issues/PRs on this repo
 * [Contributing](#contributing)
   * [TODOs](#todos)
 
+## Alta01 Updates (using Copilot)
+
+* **Tenant selector and account flow improvements**
+  * Sign in first, then select tenant from discovered tenants before loading subscriptions.
+  * Added support for saved accounts with known tenants and selectable default tenant behavior.
+  * Reduced duplicate login prompts in common account/tenant switch flows.
+* **Subscription vault selection improvements**
+  * Better handling for "Pick vault from subscription..." and immediate vault activation after selecting a vault.
+  * Improved quick switching behavior with persisted last selected vault.
+  * Added clearer onboarding/error messages when no accounts or subscriptions are configured yet.
+* **Platform/runtime modernization**
+  * Migrated Windows projects to **.NET 10** target frameworks.
+  * Updated build compatibility for current `dotnet` tooling and maintained vulnerability-clean package baseline.
+* **Release and deployment hardening**
+  * ClickOnce release workflow is configured in `.github/workflows/release.yml` and uses `release.ps1`.
+  * Release docs are now fork-specific and include tag-driven publish steps (`release.md`).
+* **Deprecated package validation status**
+  * Deprecated package scan was re-run and confirms legacy Azure SDK packages are still present.
+  * Migration to non-deprecated Azure SDK Track 2 packages remains an open refactor backlog item.
+
 ## Key features
 
 * Best user experience for authentication, you will be prompted at most *once* to enter your credentials
 * All types of authentications are supported: Certificate, Secret and User based with 2FA (including PHX or GME)
-* One click activation, just run this: `https://reysic.github.io/AzureKeyVaultExplorer?vault://[ENTER HERE YOUR VAULT NAME]`
+* One click activation, just run this: `https://alta01.github.io/AzureKeyVaultExplorer?vault://[ENTER HERE YOUR VAULT NAME]`
 * Support single or dual vaults
 * Upload and download certificate (.pfx, .p12 and .cer) files
 * Import and export certificates to user or machine stores in just few clicks
@@ -68,7 +90,7 @@ Contact: Submit issues/PRs on this repo
 
 There are 4 ways how you can make Vault Explorer to work with your vaults:
 
-1. In case Vault Explorer is not installed on the box, you may just run: reysic.github.io/AzureKeyVaultExplorer?vault://[ENTER HERE YOUR VAULT NAME]`
+1. In case Vault Explorer is not installed on the box, you may just run: alta01.github.io/AzureKeyVaultExplorer?vault://[ENTER HERE YOUR VAULT NAME]`
 2. In case Vault Explorer already installed on the box, you can just hit Win+R type `vault://[ENTER HERE YOUR VAULT NAME]` and hit Enter
     * Note: The above two methods do **NOT** allow for alternative account login  
 3. Run Vault Explorer, open vault combo box, select last item "Pick vault from subscription..."  
@@ -95,7 +117,7 @@ Just complete the below fairly easy manual steps *once*:
 * Enter - edit item
 * Ctrl + A - select all items
 * Ctrl + C - copy item value to clipboard for some time (configurable)
-* Ctrl + Shift + C - copy link to the selected item in the following format: `https://reysic.github.io/AzureKeyVaultExplorer?vault://vaultName/collection/itemName/version`
+* Ctrl + Shift + C - copy link to the selected item in the following format: `https://alta01.github.io/AzureKeyVaultExplorer?vault://vaultName/collection/itemName/version`
 * Ctrl + D - add item to favorites / remove item from favorites
 * Ctrl + E - edit item
 * Ctrl + F - find items
@@ -301,16 +323,18 @@ Telemetry can be disabled in the Settings dialog. Set *Disable telemetry* to *Tr
 
 ### Building
 
-This project has been tested with Visual Studio 2022 and .NET Framework 4.8. To build locally:
+This fork is tested with Visual Studio 2022 and .NET 10 SDK. To build locally:
 
 * Clone this repo
-* Build and run
+* Install .NET 10 SDK (`dotnet --list-sdks` should show `10.x`)
+* Run `dotnet build AzureKeyVaultExplorer.sln`
+* Run and test the application from `Vault\Explorer`
 
 PRs are welcome!
 
 ### Publishing
 
-See [release.md](https://github.com/reysic/AzureKeyVaultExplorer/blob/c6c5153fc071ef74d306dff636df2f432d6dc27e/release.md). Following that process automatically triggers a couple of [Actions](https://github.com/reysic/AzureKeyVaultExplorer/actions), which run [release.ps1](https://github.com/reysic/AzureKeyVaultExplorer/blob/c6c5153fc071ef74d306dff636df2f432d6dc27e/release.ps1).
+See [release.md](./release.md). Following that process triggers [Actions](https://github.com/alta01/AzureKeyVaultExplorer/actions), which run [release.ps1](https://github.com/alta01/AzureKeyVaultExplorer/blob/main/release.ps1).
 
 ### TODOs
 
@@ -321,13 +345,14 @@ See [release.md](https://github.com/reysic/AzureKeyVaultExplorer/blob/c6c5153fc0
   * Microsoft.IdentityModel.Clients.ActiveDirectory
   * Microsoft.Rest.ClientRuntime
   * Microsoft.Rest.ClientRuntime.Azure
+  * Status: Validation completed; migration to non-deprecated replacements is still pending.
 * Setup ClickOnce deployment
   * Re-establish existing ClickOnce install with new URL - :white_check_mark:
   * Document release process - :white_check_mark:
   * Configure ClickOnce deployments for future releases - :white_check_mark:
 * Improve onboarding
-  * Better error messaging if user hasn't configured subscription dialog values
-* Update README.md to reflect latest  state
+  * Better error messaging if user hasn't configured subscription dialog values - :white_check_mark:
+* Update README.md to reflect latest state - :white_check_mark:
 
 #### softworkz Updates
 

--- a/Vault/Build/t4.targets
+++ b/Vault/Build/t4.targets
@@ -1,150 +1,19 @@
 <!--
-// Copyright (c) Microsoft Corporation. All rights reserved. 
-// Licensed under the MIT License. See License.txt in the project root for license information. 
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup>
     <T4ToolPath>$(MSBuildThisFileDirectory)t4.exe</T4ToolPath>
-
-    <!-- The default output directory is the same as the input -->
     <T4Output Condition="$(T4Output) == ''">.</T4Output>
   </PropertyGroup>
-  
-  <!-- Inline task for parallel T4 transform execution -->
-  <UsingTask TaskName="T4TransformTask" 
-             TaskFactory="CodeTaskFactory" 
-             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll"
-             >
-    
-    <ParameterGroup>
-      <ToolPath ParameterType="System.String" Required="true" />
-      <Inputs ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.Diagnostics" />
-      <Using Namespace="System.Linq" />
-      <Using Namespace="System.Threading.Tasks" />
-      <Code Type="Method" Language="cs">
-        <![CDATA[
-        public override bool Execute()
-        {
-            Func<string, bool> getBoolFlag = (flag) => 
-              {
-                  flag = flag.Trim();
-                
-                  if (!String.IsNullOrEmpty(flag))
-                  {
-                      return Boolean.Parse(flag);
-                  }
-                
-                  return false;
-              };
 
-            //
-            // Create a list of work items
-            //
-            var workItems = Inputs.Select(input => new 
-            {  
-                InputFile = input.ItemSpec, 
-
-                OutputFile = input.GetMetadata("T4OutputFile"), 
-                Options = input.GetMetadata("T4AdditionalOptions"), 
-                Preprocess = getBoolFlag(input.GetMetadata("T4PreprocessTemplate")), 
-                                                        
-                Output = new StringBuilder(), 
-            }).ToList();
-
-            var exitCodes = new int[workItems.Count];
-            
-            Log.LogMessage("(T4) Compiling {0} items ...", workItems.Count);
-
-            //
-            // Start a task for each work item
-            //
-            var tasks = workItems.Select((wi, n) => 
-              System.Threading.Tasks.Task.Factory.StartNew(delegate
-              {
-                  var preprocess = wi.Preprocess;
-                
-                  var psi = new ProcessStartInfo() 
-                  { 
-                      FileName = ToolPath, 
-                      Arguments = (preprocess ? "-pp " : "") + wi.InputFile + " " + wi.Options + " -out " + wi.OutputFile, 
-
-                      UseShellExecute = false, CreateNoWindow = true, 
-                      RedirectStandardOutput = true, RedirectStandardError = true, 
-                  };
-                
-                  using (var t4Proc = new Process())
-                  {
-                      t4Proc.OutputDataReceived += (s, e) => { wi.Output.AppendLine(e.Data); };
-                      t4Proc.ErrorDataReceived += (s, e) => { wi.Output.AppendLine(e.Data); };
-
-                      t4Proc.StartInfo = psi;
-                      t4Proc.Start();
-
-                      t4Proc.BeginOutputReadLine();
-                      t4Proc.BeginErrorReadLine();
-
-                      t4Proc.WaitForExit();
-
-                      t4Proc.CancelOutputRead();
-                      t4Proc.CancelErrorRead();
-
-                      exitCodes[n] = t4Proc.ExitCode;
-                  }
-                
-              }, TaskCreationOptions.LongRunning)).ToArray();
-          
-            //
-            // Wait for all tasks to complete
-            //
-            System.Threading.Tasks.Task.WaitAll(tasks);
-
-            var success = true;
-          
-            for (int n = 0; n < workItems.Count; n++)
-            {
-                var wi = workItems[n];
-
-                var output = wi.Output.ToString().Trim();
-                
-                if (!String.IsNullOrEmpty(output))
-                {
-                    Log.LogMessage(MessageImportance.High, output);
-                }
-              
-                var exitCode = exitCodes[n];
-                
-                if (exitCode != 0)
-                {
-                    success = false;
-                }
-            }
-          
-            //
-            // Indicate overall success or failure
-            //
-            if (!success)
-            {
-                Log.LogError("T4Transform task failed!");
-            }
-            
-            return success;
-        }
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-  
   <ItemDefinitionGroup>
     <T4Compile>
       <T4OutputFile>$(T4Output)\%(RelativeDir)%(Filename)</T4OutputFile>
-      <!-- Note: no additional inputs by default -->
       <T4AdditionalInputs />
-      <!-- Note: should be defined as 'non-empty' to force T4 compile -->
+      <T4AdditionalOptions />
+      <T4PreprocessTemplate>false</T4PreprocessTemplate>
       <T4ForceOutput />
     </T4Compile>
   </ItemDefinitionGroup>
@@ -152,32 +21,20 @@
   <PropertyGroup>
     <T4BeforeTargets Condition="$(T4BeforeTargets) == '' and $(T4AfterTargets) == ''">BeforeBuild</T4BeforeTargets>
   </PropertyGroup>
-  
-  <!-- T4 build target -->
+
   <Target Name="BuildT4"
-    BeforeTargets="$(T4BeforeTargets)"
-    AfterTargets="$(T4AfterTargets)"
-         
-    Inputs="@(T4Compile);%(T4AdditionalInputs)" 
-    Outputs="%(T4OutputFile)%(T4ForceOutput)"
-    >
-    
-    <!-- Display message -->
+          BeforeTargets="$(T4BeforeTargets)"
+          AfterTargets="$(T4AfterTargets)"
+          Inputs="@(T4Compile);%(T4AdditionalInputs)"
+          Outputs="%(T4OutputFile)%(T4ForceOutput)">
     <Message Text="Compiling T4 templates - @(T4Compile) ..." />
-
-    <!-- Cleanup from previous run -->
     <Delete Files="%(T4Compile.T4OutputFile)" />
-
-    <!-- Invoke the task for parallel transform -->
-    <T4TransformTask ToolPath="$(T4ToolPath)" Inputs="@(T4Compile)" />
-
+    <Exec Command="&quot;$(T4ToolPath)&quot; %(T4Compile.Identity) %(T4Compile.T4AdditionalOptions) -out %(T4Compile.T4OutputFile)"
+          WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
-  
-  <!-- Hook up the T4 clean target -->
-  <!-- T4 clean target -->
+
   <Target Name="CleanT4" BeforeTargets="BeforeClean">
     <Delete Files="%(T4Compile.T4OutputFile)" />
   </Target>
-  
 </Project>
 

--- a/Vault/ClearClipboard/ClearClipboard.csproj
+++ b/Vault/ClearClipboard/ClearClipboard.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AutoVersioning>true</AutoVersioning>
-    <GenerateManifests>true</GenerateManifests>
+    <GenerateManifests>false</GenerateManifests>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>disable</Nullable>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>

--- a/Vault/Explorer/Common/ActivationUri.cs
+++ b/Vault/Explorer/Common/ActivationUri.cs
@@ -75,8 +75,9 @@ namespace Microsoft.Vault.Explorer.Common
                     return;
                 case VaultUriCollection.Certificates:
                     var cb = vault.GetCertificateAsync(this.ItemName, this.Version, CancellationToken.None).GetAwaiter().GetResult();
+                    var cbPolicy = vault.GetCertificatePolicyAsync(this.ItemName, CancellationToken.None).GetAwaiter().GetResult();
                     var cert = vault.GetCertificateWithExportableKeysAsync(this.ItemName, this.Version, CancellationToken.None).GetAwaiter().GetResult();
-                    po = new PropertyObjectCertificate(cb, cb.Policy, cert, null);
+                    po = new PropertyObjectCertificate(cb, cbPolicy, cert, null);
                     break;
                 case VaultUriCollection.Secrets:
                     var s = vault.GetSecretAsync(this.ItemName, this.Version, CancellationToken.None).GetAwaiter().GetResult();

--- a/Vault/Explorer/Common/ActivationUri.cs
+++ b/Vault/Explorer/Common/ActivationUri.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Vault.Explorer.Common
                 return Empty;
             }
 
+            // Ignore ClickOnce deployment URIs that do not include a vault: payload.
+            if (!vaultUri.StartsWith("vault:", StringComparison.CurrentCultureIgnoreCase))
+            {
+                return Empty;
+            }
+
             return new ActivationUri(vaultUri.TrimEnd('/', '\\'));
         }
 

--- a/Vault/Explorer/Common/Utils.cs
+++ b/Vault/Explorer/Common/Utils.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Vault.Explorer.Common
                 var n = Enumerable.Range(0, 1).Select(i => NumbersSet[r.Next(0, NumbersSet.Length)]);
                 var s = Enumerable.Range(0, 4).Select(i => SpecialCharsSet[r.Next(0, SpecialCharsSet.Length)]);
                 var a = Enumerable.Range(0, length - 11).Select(i => All[r.Next(0, All.Length)]);
-                return Encoding.ASCII.GetString(u.Concat(l).Concat(n).Concat(s).Concat(a).Shuffle().ToArray());
+                return Encoding.ASCII.GetString(Microsoft.Vault.Library.Utils.Shuffle(u.Concat(l).Concat(n).Concat(s).Concat(a)).ToArray());
             }
         }
 

--- a/Vault/Explorer/Common/UxOperation.cs
+++ b/Vault/Explorer/Common/UxOperation.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Vault.Explorer.Common
     using System.Threading;
     using System.Threading.Tasks;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault.Models;
-    using Microsoft.Rest.Azure;
+    using Azure;
     using Microsoft.Vault.Explorer.Model.Files.Aliases;
 
     /// <summary>
@@ -95,13 +94,9 @@ namespace Microsoft.Vault.Explorer.Common
                     {
                         await t();
                     }
-                    catch (CloudException ce) when (ce.Response?.StatusCode == System.Net.HttpStatusCode.Forbidden)
+                    catch (RequestFailedException rfe) when (rfe.Status == 403)
                     {
-                        exceptions.Enqueue(ce);
-                    }
-                    catch (KeyVaultErrorException kvce) when (kvce.Response?.StatusCode == System.Net.HttpStatusCode.Forbidden)
-                    {
-                        exceptions.Enqueue(kvce);
+                        exceptions.Enqueue(rfe);
                     }
                 }));
             }

--- a/Vault/Explorer/Controls/Lists/ListViewItemBase.cs
+++ b/Vault/Explorer/Controls/Lists/ListViewItemBase.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
     using System.Threading;
     using System.Threading.Tasks;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault;
     using Microsoft.Vault.Explorer.Common;
     using Microsoft.Vault.Explorer.Controls.Lists.Favorites;
     using Microsoft.Vault.Explorer.Model;

--- a/Vault/Explorer/Controls/Lists/ListViewItemCertificate.cs
+++ b/Vault/Explorer/Controls/Lists/ListViewItemCertificate.cs
@@ -11,40 +11,56 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
     using System.Threading;
     using System.Threading.Tasks;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Certificates;
     using Microsoft.Vault.Explorer.Common;
     using Microsoft.Vault.Explorer.Dialogs.Certificates;
     using Microsoft.Vault.Explorer.Model;
     using Microsoft.Vault.Explorer.Model.ContentTypes;
     using Microsoft.Vault.Explorer.Model.PropObjects;
+    using Microsoft.Vault.Library;
 
     /// <summary>
     ///     Key Vault Certificate list view item which also presents itself nicely to PropertyGrid
     /// </summary>
     public class ListViewItemCertificate : ListViewItemBase
     {
-        public readonly CertificateAttributes Attributes;
         public readonly string Thumbprint;
 
-        private ListViewItemCertificate(ISession session, CertificateIdentifier identifier, CertificateAttributes attributes, string thumbprint, IDictionary<string, string> tags) :
-            base(session, KeyVaultCertificatesGroup, identifier, tags, attributes.Enabled, attributes.Created, attributes.Updated, attributes.NotBefore, attributes.Expires)
+        private ListViewItemCertificate(ISession session, ObjectIdentifier identifier, string thumbprint, IDictionary<string, string> tags, bool? enabled, DateTime? created, DateTime? updated, DateTime? notBefore, DateTime? expires) :
+            base(session, KeyVaultCertificatesGroup, identifier, tags, enabled, created, updated, notBefore, expires)
         {
-            this.Attributes = attributes;
             this.Thumbprint = thumbprint?.ToLowerInvariant();
         }
 
-        public ListViewItemCertificate(ISession session, CertificateItem c) : this(session, c.Identifier, c.Attributes, Utils.ByteArrayToHex(c.X509Thumbprint), c.Tags)
+        public ListViewItemCertificate(ISession session, CertificateProperties cp) : this(
+            session,
+            new ObjectIdentifier(cp.Name, cp.Id?.ToString() ?? string.Empty, cp.Version ?? string.Empty, cp.VaultUri?.ToString() ?? string.Empty),
+            Utils.ByteArrayToHex(cp.X509Thumbprint),
+            cp.Tags,
+            cp.Enabled,
+            cp.CreatedOn?.UtcDateTime,
+            cp.UpdatedOn?.UtcDateTime,
+            cp.NotBefore?.UtcDateTime,
+            cp.ExpiresOn?.UtcDateTime)
         {
         }
 
-        public ListViewItemCertificate(ISession session, CertificateBundle cb) : this(session, cb.CertificateIdentifier, cb.Attributes, Utils.ByteArrayToHex(cb.X509Thumbprint), cb.Tags)
+        public ListViewItemCertificate(ISession session, KeyVaultCertificate kvc) : this(
+            session,
+            new ObjectIdentifier(kvc.Name, kvc.Id?.ToString() ?? string.Empty, kvc.Properties.Version ?? string.Empty, kvc.Properties.VaultUri?.ToString() ?? string.Empty),
+            Utils.ByteArrayToHex(kvc.Properties.X509Thumbprint),
+            kvc.Properties.Tags,
+            kvc.Properties.Enabled,
+            kvc.Properties.CreatedOn?.UtcDateTime,
+            kvc.Properties.UpdatedOn?.UtcDateTime,
+            kvc.Properties.NotBefore?.UtcDateTime,
+            kvc.Properties.ExpiresOn?.UtcDateTime)
         {
         }
 
         protected override IEnumerable<PropertyDescriptor> GetCustomProperties()
         {
-            yield return new ReadOnlyPropertyDescriptor("Content Type", CertificateContentType.Pfx);
+            yield return new ReadOnlyPropertyDescriptor("Content Type", CertificateContentType.Pkcs12.ToString());
             yield return new ReadOnlyPropertyDescriptor("Thumbprint", this.Thumbprint);
         }
 
@@ -52,26 +68,36 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
 
         public override async Task<PropertyObject> GetAsync(CancellationToken cancellationToken)
         {
-            var cb = await this.Session.CurrentVault.GetCertificateAsync(this.Name, null, cancellationToken);
+            var kvc = await this.Session.CurrentVault.GetCertificateAsync(this.Name, null, cancellationToken);
+            var policy = await this.Session.CurrentVault.GetCertificatePolicyAsync(this.Name, cancellationToken);
             var cert = await this.Session.CurrentVault.GetCertificateWithExportableKeysAsync(this.Name, null, cancellationToken);
-            return new PropertyObjectCertificate(cb, cb.Policy, cert, null);
+            return new PropertyObjectCertificate(kvc, policy, cert, null);
         }
 
         public override async Task<ListViewItemBase> ToggleAsync(CancellationToken cancellationToken)
         {
-            CertificateBundle cb = await this.Session.CurrentVault.UpdateCertificateAsync(this.Name, null, null, new CertificateAttributes { Enabled = !this.Attributes.Enabled }, this.Tags, cancellationToken); // Toggle only Enabled attribute
-            return new ListViewItemCertificate(this.Session, cb);
+            var kvc = await this.Session.CurrentVault.UpdateCertificateAsync(
+                this.Name, null,
+                !this.Enabled,
+                this.Expires.HasValue ? (DateTimeOffset?)this.Expires.Value : null,
+                this.NotBefore.HasValue ? (DateTimeOffset?)this.NotBefore.Value : null,
+                this.Tags,
+                cancellationToken);
+            return new ListViewItemCertificate(this.Session, kvc);
         }
 
         public override async Task<ListViewItemBase> ResetExpirationAsync(CancellationToken cancellationToken)
         {
-            var ca = new CertificateAttributes
-            {
-                NotBefore = this.NotBefore == null ? null : DateTime.UtcNow.AddHours(-1),
-                Expires = this.Expires == null ? null : DateTime.UtcNow.AddYears(1),
-            };
-            CertificateBundle cb = await this.Session.CurrentVault.UpdateCertificateAsync(this.Name, null, null, ca, this.Tags, cancellationToken); // Reset only NotBefore and Expires attributes
-            return new ListViewItemCertificate(this.Session, cb);
+            DateTimeOffset? newExpires = this.Expires == null ? null : (DateTimeOffset?)DateTimeOffset.UtcNow.AddYears(1);
+            DateTimeOffset? newNotBefore = this.NotBefore == null ? null : (DateTimeOffset?)DateTimeOffset.UtcNow.AddHours(-1);
+            var kvc = await this.Session.CurrentVault.UpdateCertificateAsync(
+                this.Name, null,
+                this.Enabled,
+                newExpires,
+                newNotBefore,
+                this.Tags,
+                cancellationToken);
+            return new ListViewItemCertificate(this.Session, kvc);
         }
 
         public override async Task<ListViewItemBase> DeleteAsync(CancellationToken cancellationToken)
@@ -87,16 +113,21 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
 
         public override Form GetEditDialog(string name, IEnumerable<object> versions)
         {
-            return new CertificateDialog(this.Session, name, versions.Cast<CertificateItem>());
+            return new CertificateDialog(this.Session, name, versions.Cast<CertificateProperties>());
         }
 
         public override async Task<ListViewItemBase> UpdateAsync(object originalObject, PropertyObject newObject, CancellationToken cancellationToken)
         {
-            CertificateBundle cb = (CertificateBundle)originalObject;
             PropertyObjectCertificate certNew = (PropertyObjectCertificate)newObject;
             await this.Session.CurrentVault.UpdateCertificatePolicyAsync(certNew.Name, certNew.CertificatePolicy, cancellationToken);
-            cb = await this.Session.CurrentVault.UpdateCertificateAsync(certNew.Name, null, null, certNew.ToCertificateAttributes(), certNew.ToTagsDictionary(), cancellationToken);
-            return new ListViewItemCertificate(this.Session, cb);
+            var kvc = await this.Session.CurrentVault.UpdateCertificateAsync(
+                certNew.Name, null,
+                certNew.Enabled,
+                certNew.Expires.HasValue ? (DateTimeOffset?)certNew.Expires.Value : null,
+                certNew.NotBefore.HasValue ? (DateTimeOffset?)certNew.NotBefore.Value : null,
+                certNew.ToTagsDictionary(),
+                cancellationToken);
+            return new ListViewItemCertificate(this.Session, kvc);
         }
 
         public static async Task<ListViewItemCertificate> NewAsync(ISession session, PropertyObject newObject, CancellationToken cancellationToken)
@@ -104,8 +135,12 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
             PropertyObjectCertificate certNew = (PropertyObjectCertificate)newObject;
             var certCollection = new X509Certificate2Collection();
             certCollection.Add(certNew.Certificate);
-            CertificateBundle cb = await session.CurrentVault.ImportCertificateAsync(certNew.Name, certCollection, certNew.CertificatePolicy, certNew.CertificateBundle.Attributes, certNew.ToTagsDictionary(), cancellationToken);
-            return new ListViewItemCertificate(session, cb);
+            var kvc = await session.CurrentVault.ImportCertificateAsync(
+                certNew.Name, certCollection, certNew.CertificatePolicy,
+                certNew.Enabled,
+                certNew.ToTagsDictionary(),
+                cancellationToken);
+            return new ListViewItemCertificate(session, kvc);
         }
     }
 }

--- a/Vault/Explorer/Controls/Lists/ListViewItemSecret.cs
+++ b/Vault/Explorer/Controls/Lists/ListViewItemSecret.cs
@@ -10,37 +10,53 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
     using System.Threading;
     using System.Threading.Tasks;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Secrets;
     using Microsoft.Vault.Explorer.Common;
     using Microsoft.Vault.Explorer.Dialogs.Secrets;
     using Microsoft.Vault.Explorer.Model;
     using Microsoft.Vault.Explorer.Model.ContentTypes;
     using Microsoft.Vault.Explorer.Model.PropObjects;
+    using Microsoft.Vault.Library;
 
     /// <summary>
     ///     Secret list view item which also presents itself nicely to PropertyGrid
     /// </summary>
     public class ListViewItemSecret : ListViewItemBase
     {
-        public readonly SecretAttributes Attributes;
         public readonly string ContentTypeStr;
         public readonly ContentType ContentType;
 
-        private ListViewItemSecret(ISession session, SecretIdentifier identifier, SecretAttributes attributes, string contentTypeStr, IDictionary<string, string> tags) :
+        private ListViewItemSecret(ISession session, ObjectIdentifier identifier, string contentTypeStr, IDictionary<string, string> tags, bool? enabled, DateTime? created, DateTime? updated, DateTime? notBefore, DateTime? expires) :
             base(session, ContentTypeEnumConverter.GetValue(contentTypeStr).IsCertificate() ? CertificatesGroup : SecretsGroup,
-                identifier, tags, attributes.Enabled, attributes.Created, attributes.Updated, attributes.NotBefore, attributes.Expires)
+                identifier, tags, enabled, created, updated, notBefore, expires)
         {
-            this.Attributes = attributes;
             this.ContentTypeStr = contentTypeStr;
             this.ContentType = ContentTypeEnumConverter.GetValue(contentTypeStr);
         }
 
-        public ListViewItemSecret(ISession session, SecretItem si) : this(session, si.Identifier, si.Attributes, si.ContentType, si.Tags)
+        public ListViewItemSecret(ISession session, SecretProperties sp) : this(
+            session,
+            new ObjectIdentifier(sp.Name, sp.Id?.ToString() ?? string.Empty, sp.Version ?? string.Empty, sp.VaultUri?.ToString() ?? string.Empty),
+            sp.ContentType,
+            sp.Tags,
+            sp.Enabled,
+            sp.CreatedOn?.UtcDateTime,
+            sp.UpdatedOn?.UtcDateTime,
+            sp.NotBefore?.UtcDateTime,
+            sp.ExpiresOn?.UtcDateTime)
         {
         }
 
-        public ListViewItemSecret(ISession session, SecretBundle s) : this(session, s.SecretIdentifier, s.Attributes, s.ContentType, s.Tags)
+        public ListViewItemSecret(ISession session, KeyVaultSecret s) : this(
+            session,
+            new ObjectIdentifier(s.Name, s.Id?.ToString() ?? string.Empty, s.Properties.Version ?? string.Empty, s.Properties.VaultUri?.ToString() ?? string.Empty),
+            s.Properties.ContentType,
+            s.Properties.Tags,
+            s.Properties.Enabled,
+            s.Properties.CreatedOn?.UtcDateTime,
+            s.Properties.UpdatedOn?.UtcDateTime,
+            s.Properties.NotBefore?.UtcDateTime,
+            s.Properties.ExpiresOn?.UtcDateTime)
         {
         }
 
@@ -59,19 +75,30 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
 
         public override async Task<ListViewItemBase> ToggleAsync(CancellationToken cancellationToken)
         {
-            SecretBundle s = await this.Session.CurrentVault.UpdateSecretAsync(this.Name, null, new Dictionary<string, string>(this.Tags), null, new SecretAttributes { Enabled = !this.Attributes.Enabled }, cancellationToken); // Toggle only Enabled attribute
-            return new ListViewItemSecret(this.Session, s);
+            var sp = await this.Session.CurrentVault.UpdateSecretAsync(
+                this.Name, null,
+                new Dictionary<string, string>(this.Tags),
+                this.ContentTypeStr,
+                !this.Enabled,
+                this.Expires.HasValue ? (DateTimeOffset?)this.Expires.Value : null,
+                this.NotBefore.HasValue ? (DateTimeOffset?)this.NotBefore.Value : null,
+                cancellationToken);
+            return new ListViewItemSecret(this.Session, sp);
         }
 
         public override async Task<ListViewItemBase> ResetExpirationAsync(CancellationToken cancellationToken)
         {
-            var sa = new SecretAttributes
-            {
-                NotBefore = this.NotBefore == null ? null : DateTime.UtcNow.AddHours(-1),
-                Expires = this.Expires == null ? null : DateTime.UtcNow.AddYears(1),
-            };
-            SecretBundle s = await this.Session.CurrentVault.UpdateSecretAsync(this.Name, null, new Dictionary<string, string>(this.Tags), null, sa, cancellationToken); // Reset only NotBefore and Expires attributes
-            return new ListViewItemSecret(this.Session, s);
+            DateTimeOffset? newExpires = this.Expires == null ? null : (DateTimeOffset?)DateTimeOffset.UtcNow.AddYears(1);
+            DateTimeOffset? newNotBefore = this.NotBefore == null ? null : (DateTimeOffset?)DateTimeOffset.UtcNow.AddHours(-1);
+            var sp = await this.Session.CurrentVault.UpdateSecretAsync(
+                this.Name, null,
+                new Dictionary<string, string>(this.Tags),
+                this.ContentTypeStr,
+                this.Enabled,
+                newExpires,
+                newNotBefore,
+                cancellationToken);
+            return new ListViewItemSecret(this.Session, sp);
         }
 
         public override async Task<ListViewItemBase> DeleteAsync(CancellationToken cancellationToken)
@@ -87,31 +114,42 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
 
         public override Form GetEditDialog(string name, IEnumerable<object> versions)
         {
-            return new SecretDialog(this.Session, name, versions.Cast<SecretItem>());
+            return new SecretDialog(this.Session, name, versions.Cast<SecretProperties>());
         }
 
         private static async Task<ListViewItemSecret> NewOrUpdateAsync(ISession session, object originalObject, PropertyObject newObject, CancellationToken cancellationToken)
         {
-            SecretBundle sOriginal = (SecretBundle)originalObject;
+            KeyVaultSecret sOriginal = (KeyVaultSecret)originalObject;
             PropertyObjectSecret posNew = (PropertyObjectSecret)newObject;
-            SecretBundle s = null;
-            // New secret, secret rename or new value
-            if (sOriginal == null || sOriginal.SecretIdentifier.Name != posNew.Name || sOriginal.Value != posNew.RawValue)
-            {
-                s = await session.CurrentVault.SetSecretAsync(posNew.Name, posNew.RawValue, posNew.ToTagsDictionary(), ContentTypeEnumConverter.GetDescription(posNew.ContentType), posNew.ToSecretAttributes(), cancellationToken);
-            }
-            else // Same secret name and value
-            {
-                s = await session.CurrentVault.UpdateSecretAsync(posNew.Name, null, posNew.ToTagsDictionary(), ContentTypeEnumConverter.GetDescription(posNew.ContentType), posNew.ToSecretAttributes(), cancellationToken);
-            }
 
-            string oldSecretName = sOriginal?.SecretIdentifier.Name;
-            if (oldSecretName != null && oldSecretName != posNew.Name) // Delete old secret
-            {
-                await session.CurrentVault.DeleteSecretAsync(oldSecretName, cancellationToken);
-            }
+            DateTimeOffset? expires = posNew.Expires.HasValue ? (DateTimeOffset?)posNew.Expires.Value : null;
+            DateTimeOffset? notBefore = posNew.NotBefore.HasValue ? (DateTimeOffset?)posNew.NotBefore.Value : null;
 
-            return new ListViewItemSecret(session, s);
+            // New secret, rename, or new value
+            if (sOriginal == null || sOriginal.Name != posNew.Name || sOriginal.Value != posNew.RawValue)
+            {
+                var s = await session.CurrentVault.SetSecretAsync(
+                    posNew.Name, posNew.RawValue, posNew.ToTagsDictionary(),
+                    ContentTypeEnumConverter.GetDescription(posNew.ContentType),
+                    posNew.Enabled, expires, notBefore, cancellationToken);
+
+                string oldSecretName = sOriginal?.Name;
+                if (oldSecretName != null && oldSecretName != posNew.Name)
+                {
+                    await session.CurrentVault.DeleteSecretAsync(oldSecretName, cancellationToken);
+                }
+
+                return new ListViewItemSecret(session, s);
+            }
+            else // Same secret name and value — update metadata only
+            {
+                var sp = await session.CurrentVault.UpdateSecretAsync(
+                    posNew.Name, null, posNew.ToTagsDictionary(),
+                    ContentTypeEnumConverter.GetDescription(posNew.ContentType),
+                    posNew.Enabled, expires, notBefore, cancellationToken);
+
+                return new ListViewItemSecret(session, sp);
+            }
         }
 
         public override async Task<ListViewItemBase> UpdateAsync(object originalObject, PropertyObject newObject, CancellationToken cancellationToken)

--- a/Vault/Explorer/Controls/Lists/ListViewSecrets.Designer.cs
+++ b/Vault/Explorer/Controls/Lists/ListViewSecrets.Designer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
             // 
             // columnHeader4
             // 
-            this.columnHeader4.Text = "Expires";
+            this.columnHeader4.Text = "Expires in";
             this.columnHeader4.Width = 100;
             // 
             // uxSmallImageList

--- a/Vault/Explorer/Controls/Lists/ListViewSecrets.cs
+++ b/Vault/Explorer/Controls/Lists/ListViewSecrets.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Vault.Explorer.Controls.Lists
 {
     using System;
+    using System.ComponentModel;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -16,6 +17,7 @@ namespace Microsoft.Vault.Explorer.Controls.Lists
     {
         public const int FirstCustomColumnIndex = 4;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int SortingColumn { get; set; }
 
         public ListViewSecrets()

--- a/Vault/Explorer/Controls/MenuItems/CertificateVersion.cs
+++ b/Vault/Explorer/Controls/MenuItems/CertificateVersion.cs
@@ -1,12 +1,22 @@
 namespace Microsoft.Vault.Explorer.Controls.MenuItems
 {
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Certificates;
+    using Microsoft.Vault.Library;
 
     public class CertificateVersion : CustomVersion
     {
-        public readonly CertificateItem CertificateItem;
+        public readonly CertificateProperties CertificateItem;
 
-        public CertificateVersion(int index, CertificateItem certificateItem) : base(index, certificateItem.Attributes.Created, certificateItem.Attributes.Updated, Library.Utils.GetChangedBy(certificateItem.Tags), certificateItem.Identifier)
+        public CertificateVersion(int index, CertificateProperties certificateItem) : base(
+            index,
+            certificateItem.CreatedOn?.UtcDateTime,
+            certificateItem.UpdatedOn?.UtcDateTime,
+            Library.Utils.GetChangedBy(certificateItem.Tags),
+            new ObjectIdentifier(
+                certificateItem.Name,
+                certificateItem.Id?.ToString() ?? string.Empty,
+                certificateItem.Version ?? string.Empty,
+                certificateItem.VaultUri?.ToString() ?? string.Empty))
         {
             this.CertificateItem = certificateItem;
         }

--- a/Vault/Explorer/Controls/MenuItems/CustomVersion.cs
+++ b/Vault/Explorer/Controls/MenuItems/CustomVersion.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Vault.Explorer.Controls.MenuItems
 {
     using System;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault;
     using Microsoft.Vault.Explorer.Common;
+    using Microsoft.Vault.Library;
 
     public abstract class CustomVersion : ToolStripMenuItem
     {

--- a/Vault/Explorer/Controls/MenuItems/SecretVersion.cs
+++ b/Vault/Explorer/Controls/MenuItems/SecretVersion.cs
@@ -1,12 +1,22 @@
 namespace Microsoft.Vault.Explorer.Controls.MenuItems
 {
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Secrets;
+    using Microsoft.Vault.Library;
 
     public class SecretVersion : CustomVersion
     {
-        public readonly SecretItem SecretItem;
+        public readonly SecretProperties SecretItem;
 
-        public SecretVersion(int index, SecretItem secretItem) : base(index, secretItem.Attributes.Created, secretItem.Attributes.Updated, Library.Utils.GetChangedBy(secretItem.Tags), secretItem.Identifier)
+        public SecretVersion(int index, SecretProperties secretItem) : base(
+            index,
+            secretItem.CreatedOn?.UtcDateTime,
+            secretItem.UpdatedOn?.UtcDateTime,
+            Library.Utils.GetChangedBy(secretItem.Tags),
+            new ObjectIdentifier(
+                secretItem.Name,
+                secretItem.Id?.ToString() ?? string.Empty,
+                secretItem.Version ?? string.Empty,
+                secretItem.VaultUri?.ToString() ?? string.Empty))
         {
             this.SecretItem = secretItem;
         }

--- a/Vault/Explorer/Dialogs/Certificates/CertificateDialog.cs
+++ b/Vault/Explorer/Dialogs/Certificates/CertificateDialog.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Certificates
             switch (contentType)
             {
                 case ContentType.Certificate:
-                    cert = new X509Certificate2(fi.FullName);
+                    cert = X509CertificateLoader.LoadCertificateFromFile(fi.FullName);
                     break;
                 case ContentType.Pkcs12:
                     string password = null;
@@ -52,12 +52,12 @@ namespace Microsoft.Vault.Explorer.Dialogs.Certificates
                     }
 
                     password = pwdDlg.Password;
-                    cert = new X509Certificate2(fi.FullName, password, X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable);
+                    cert = X509CertificateLoader.LoadPkcs12FromFile(fi.FullName, password, X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable, Pkcs12LoaderLimits.Defaults);
                     break;
                 case ContentType.KeyVaultCertificate:
                     var kvcf = Utils.LoadFromJsonFile<KeyVaultCertificateFile>(fi.FullName);
                     cb = kvcf.Deserialize();
-                    cert = new X509Certificate2(cb.Cer);
+                    cert = X509CertificateLoader.LoadCertificate(cb.Cer);
                     break;
                 default:
                     throw new ArgumentException($"Unsupported ContentType {contentType}");

--- a/Vault/Explorer/Dialogs/Certificates/CertificateDialog.cs
+++ b/Vault/Explorer/Dialogs/Certificates/CertificateDialog.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Certificates
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Certificates;
     using Microsoft.Vault.Explorer.Common;
     using Microsoft.Vault.Explorer.Controls.MenuItems;
     using Microsoft.Vault.Explorer.Dialogs.Passwords;
@@ -34,7 +34,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Certificates
         /// </summary>
         public CertificateDialog(ISession session, FileInfo fi) : this(session, "New certificate", ItemDialogBaseMode.New)
         {
-            CertificateBundle cb = null;
+            KeyVaultCertificate cb = null;
             X509Certificate2 cert = null;
             ContentType contentType = ContentTypeUtils.FromExtension(fi.Extension);
             switch (contentType)
@@ -56,8 +56,8 @@ namespace Microsoft.Vault.Explorer.Dialogs.Certificates
                     break;
                 case ContentType.KeyVaultCertificate:
                     var kvcf = Utils.LoadFromJsonFile<KeyVaultCertificateFile>(fi.FullName);
-                    cb = kvcf.Deserialize();
-                    cert = X509CertificateLoader.LoadCertificate(cb.Cer);
+                    var cfd = kvcf.Deserialize();
+                    cert = X509CertificateLoader.LoadCertificate(cfd.Cer);
                     break;
                 default:
                     throw new ArgumentException($"Unsupported ContentType {contentType}");
@@ -77,40 +77,29 @@ namespace Microsoft.Vault.Explorer.Dialogs.Certificates
         /// <summary>
         ///     Edit certificate
         /// </summary>
-        public CertificateDialog(ISession session, string name, IEnumerable<CertificateItem> versions) : this(session, $"Edit certificate {name}", ItemDialogBaseMode.Edit)
+        public CertificateDialog(ISession session, string name, IEnumerable<CertificateProperties> versions) : this(session, $"Edit certificate {name}", ItemDialogBaseMode.Edit)
         {
             this.uxTextBoxName.ReadOnly = true;
             int i = 0;
-            this.uxMenuVersions.Items.AddRange((from v in versions orderby v.Attributes.Created descending select new CertificateVersion(i++, v)).ToArray());
+            this.uxMenuVersions.Items.AddRange((from v in versions orderby v.CreatedOn descending select new CertificateVersion(i++, v)).ToArray());
             this.uxMenuVersions_ItemClicked(null, new ToolStripItemClickedEventArgs(this.uxMenuVersions.Items[0])); // Pass sender as NULL so _changed will be set to false
         }
 
-        private void NewCertificate(CertificateBundle cb, X509Certificate2 cert)
+        private void NewCertificate(KeyVaultCertificate cb, X509Certificate2 cert)
         {
-            this._certificatePolicy = cb?.Policy;
-            this._certificatePolicy = this._certificatePolicy ?? new CertificatePolicy
+            this._certificatePolicy = this._certificatePolicy ?? new CertificatePolicy("Self")
             {
-                KeyProperties = new KeyProperties
-                {
-                    Exportable = true,
-                    KeySize = 2048,
-                    KeyType = "RSA",
-                    ReuseKey = false,
-                },
-                SecretProperties = new SecretProperties
-                {
-                    ContentType = CertificateContentType.Pfx,
-                },
-            };
-            cb = cb ?? new CertificateBundle
-            {
-                Attributes = new CertificateAttributes(),
+                Exportable = true,
+                KeySize = 2048,
+                KeyType = "RSA",
+                ReuseKey = false,
+                ContentType = CertificateContentType.Pkcs12,
             };
             this.RefreshCertificateObject(cb, this._certificatePolicy, cert);
             this.uxTextBoxName.Text = Utils.ConvertToValidSecretName(cert.GetNameInfo(X509NameType.SimpleName, false));
         }
 
-        private void RefreshCertificateObject(CertificateBundle cb, CertificatePolicy cp, X509Certificate2 certificate)
+        private void RefreshCertificateObject(KeyVaultCertificate cb, CertificatePolicy cp, X509Certificate2 certificate)
         {
             this.uxPropertyGridSecret.SelectedObject = this.PropertyObject = new PropertyObjectCertificate(cb, cp, certificate, this.SecretObject_PropertyChanged);
             this.uxTextBoxName.Text = this.PropertyObject.Name;
@@ -131,11 +120,11 @@ namespace Microsoft.Vault.Explorer.Dialogs.Certificates
 
         protected override async Task<object> OnVersionChangeAsync(CustomVersion cv)
         {
-            var cb = await this._session.CurrentVault.GetCertificateAsync(cv.Id.Name, cv.Index == 0 ? null : cv.Id.Version); // Pass NULL as a version to fetch current CertificatePolicy
+            var cb = await this._session.CurrentVault.GetCertificateAsync(cv.Id.Name, cv.Index == 0 ? null : cv.Id.Version);
             var cert = await this._session.CurrentVault.GetCertificateWithExportableKeysAsync(cv.Id.Name, cv.Id.Version);
-            if (this._certificatePolicy == null && cb.Policy != null) // cb.Policy will be NULL when version is not current
+            if (this._certificatePolicy == null && cv.Index == 0) // Only fetch policy for current version
             {
-                this._certificatePolicy = cb.Policy;
+                this._certificatePolicy = await this._session.CurrentVault.GetCertificatePolicyAsync(cv.Id.Name);
             }
 
             this.RefreshCertificateObject(cb, this._certificatePolicy, cert);

--- a/Vault/Explorer/Dialogs/ItemDialogBase.cs
+++ b/Vault/Explorer/Dialogs/ItemDialogBase.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Vault.Explorer.Dialogs
 {
     using System;
+    using System.ComponentModel;
     using System.Threading.Tasks;
     using System.Windows.Forms;
     using Microsoft.Vault.Explorer.Controls.MenuItems;
@@ -16,6 +17,7 @@ namespace Microsoft.Vault.Explorer.Dialogs
         protected readonly ItemDialogBaseMode _mode;
         protected bool _changed;
         public object OriginalObject; //  Will be NULL in New mode and current value in case of Edit mode
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public PropertyObject PropertyObject { get; protected set; }
 
         public ItemDialogBase()

--- a/Vault/Explorer/Dialogs/Secrets/SecretDialog.Designer.cs
+++ b/Vault/Explorer/Dialogs/Secrets/SecretDialog.Designer.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
             this.uxLinkLabelViewCertificate = new System.Windows.Forms.LinkLabel();
             this.uxPropertyGridSecret = new System.Windows.Forms.PropertyGrid();
             this.uxLabelBytesLeft = new System.Windows.Forms.Label();
+            this.uxButtonToggleMask = new System.Windows.Forms.Button();
             this.uxTimerValueTypingCompleted = new System.Windows.Forms.Timer(this.components);
             this.uxMenuNewValue = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.uxMenuItemNewPassword = new System.Windows.Forms.ToolStripMenuItem();
@@ -110,9 +111,21 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
             this.uxPropertyGridSecret.Size = new System.Drawing.Size(986, 132);
             this.uxPropertyGridSecret.TabIndex = 0;
             this.uxPropertyGridSecret.ToolbarVisible = false;
-            // 
+            //
+            // uxButtonToggleMask
+            //
+            this.uxButtonToggleMask.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            this.uxButtonToggleMask.Location = new System.Drawing.Point(730, 61);
+            this.uxButtonToggleMask.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.uxButtonToggleMask.Name = "uxButtonToggleMask";
+            this.uxButtonToggleMask.Size = new System.Drawing.Size(48, 22);
+            this.uxButtonToggleMask.TabIndex = 11;
+            this.uxButtonToggleMask.Text = "Hide";
+            this.uxButtonToggleMask.UseVisualStyleBackColor = true;
+            this.uxButtonToggleMask.Click += this.uxButtonToggleMask_Click;
+            //
             // uxLabelBytesLeft
-            // 
+            //
             this.uxLabelBytesLeft.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             this.uxLabelBytesLeft.Location = new System.Drawing.Point(782, 64);
             this.uxLabelBytesLeft.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
@@ -164,6 +177,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1018, 613);
             this.Controls.Add(this.uxSplitContainer);
+            this.Controls.Add(this.uxButtonToggleMask);
             this.Controls.Add(this.uxLabelBytesLeft);
             this.Controls.Add(tableLayoutPanel1);
             this.Name = "SecretDialog";
@@ -182,6 +196,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
         private System.Windows.Forms.PropertyGrid uxPropertyGridSecret;
         private System.Windows.Forms.SplitContainer uxSplitContainer;
         private System.Windows.Forms.Label uxLabelBytesLeft;
+        private System.Windows.Forms.Button uxButtonToggleMask;
         private System.Windows.Forms.Timer uxTimerValueTypingCompleted;
         private System.Windows.Forms.ContextMenuStrip uxMenuNewValue;
         private System.Windows.Forms.ToolStripMenuItem uxMenuItemNewPassword;

--- a/Vault/Explorer/Dialogs/Secrets/SecretDialog.cs
+++ b/Vault/Explorer/Dialogs/Secrets/SecretDialog.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Secrets;
     using Microsoft.Vault.Explorer.Controls;
     using Microsoft.Vault.Explorer.Controls.MenuItems;
     using Microsoft.Vault.Explorer.Dialogs.Passwords;
@@ -27,7 +27,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
     using Settings = Microsoft.Vault.Explorer.Settings;
     using Utils = Microsoft.Vault.Explorer.Common.Utils;
 
-    public partial class SecretDialog : ItemDialogBase // <PropertyObjectSecret, SecretBundle>
+    public partial class SecretDialog : ItemDialogBase // <PropertyObjectSecret, KeyVaultSecret>
     {
         private CertificateValueObject _certificateObj;
         private Scintilla uxTextBoxValue;
@@ -63,8 +63,12 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
         public SecretDialog(ISession session) : this(session, "New secret", ItemDialogBaseMode.New)
         {
             this._changed = true;
-            var s = new SecretBundle { Attributes = new SecretAttributes(), ContentType = ContentTypeEnumConverter.GetDescription(ContentType.Text) };
-            this.RefreshSecretObject(s);
+            this.PropertyObject = new PropertyObjectSecret(ContentTypeEnumConverter.GetDescription(ContentType.Text), this.SecretObject_PropertyChanged);
+            this.uxPropertyGridSecret.SelectedObject = this.PropertyObject;
+            this.uxTextBoxName.Text = this.PropertyObject.Name;
+            this.uxTextBoxValue.Text = this.PropertyObject.Value;
+            var obj = (PropertyObjectSecret)this.PropertyObject;
+            this.ToggleCertificateMode(obj.ContentType.IsCertificate());
             SecretKind defaultSK = this.TryGetDefaultSecretKind();
             int defaultIndex = this.uxMenuSecretKind.Items.IndexOf(defaultSK);
             this.uxMenuSecretKind.Items[defaultIndex].PerformClick();
@@ -97,10 +101,10 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
                     break;
                 case ContentType.KeyVaultSecret:
                     var kvsf = Utils.LoadFromJsonFile<KeyVaultSecretFile>(fi.FullName);
-                    SecretBundle s = kvsf.Deserialize();
-                    this.uxPropertyGridSecret.SelectedObject = this.PropertyObject = new PropertyObjectSecret(s, this.SecretObject_PropertyChanged);
-                    this.uxTextBoxName.Text = s.SecretIdentifier?.Name;
-                    this.uxTextBoxValue.Text = s.Value;
+                    var sfd = kvsf.Deserialize();
+                    this.uxPropertyGridSecret.SelectedObject = this.PropertyObject = new PropertyObjectSecret(sfd, this.SecretObject_PropertyChanged);
+                    this.uxTextBoxName.Text = this.PropertyObject.Name;
+                    this.uxTextBoxValue.Text = this.PropertyObject.Value;
                     return;
                 default:
                     this.uxTextBoxValue.Text = File.ReadAllText(fi.FullName);
@@ -133,11 +137,11 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
         /// <summary>
         ///     Edit or Copy secret
         /// </summary>
-        public SecretDialog(ISession session, string name, IEnumerable<SecretItem> versions) : this(session, "Edit secret", ItemDialogBaseMode.Edit)
+        public SecretDialog(ISession session, string name, IEnumerable<SecretProperties> versions) : this(session, "Edit secret", ItemDialogBaseMode.Edit)
         {
             this.Text += $" {name}";
             int i = 0;
-            this.uxMenuVersions.Items.AddRange((from v in versions orderby v.Attributes.Created descending select new SecretVersion(i++, v)).ToArray());
+            this.uxMenuVersions.Items.AddRange((from v in versions orderby v.CreatedOn descending select new SecretVersion(i++, v)).ToArray());
             this.uxMenuVersions_ItemClicked(null, new ToolStripItemClickedEventArgs(this.uxMenuVersions.Items[0])); // Pass sender as NULL so _changed will be set to false
         }
 
@@ -188,7 +192,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
             return orderedValidatedSecretKinds;
         }
 
-        private void RefreshSecretObject(SecretBundle s)
+        private void RefreshSecretObject(KeyVaultSecret s)
         {
             this.PropertyObject = new PropertyObjectSecret(s, this.SecretObject_PropertyChanged);
             this.uxPropertyGridSecret.SelectedObject = this.PropertyObject;
@@ -405,7 +409,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
         protected override async Task<object> OnVersionChangeAsync(CustomVersion cv)
         {
             SecretVersion sv = (SecretVersion)cv;
-            var s = await this._session.CurrentVault.GetSecretAsync(sv.SecretItem.Identifier.Name, sv.SecretItem.Identifier.Version);
+            var s = await this._session.CurrentVault.GetSecretAsync(sv.SecretItem.Name, sv.SecretItem.Version);
             this.RefreshSecretObject(s);
             this.AutoDetectSecretKind();
             return s;

--- a/Vault/Explorer/Dialogs/Secrets/SecretDialog.cs
+++ b/Vault/Explorer/Dialogs/Secrets/SecretDialog.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
     {
         private CertificateValueObject _certificateObj;
         private Scintilla uxTextBoxValue;
+        private bool _isMasked = false;
+        private string _maskedRealValue = string.Empty;
 
         private SecretDialog(ISession session, string title, ItemDialogBaseMode mode) : base(session, title, mode)
         {
@@ -300,10 +302,33 @@ namespace Microsoft.Vault.Explorer.Dialogs.Secrets
 
         private void uxTextBoxValue_TextChanged(object sender, EventArgs e)
         {
+            if (this._isMasked)
+            {
+                return; // Value is masked; don't write bullet characters back to PropertyObject
+            }
+
             this._changed = true;
             this.PropertyObject.Value = this.uxTextBoxValue.Text;
             this.uxTimerValueTypingCompleted.Stop(); // Wait for user to finish the typing in a text box
             this.uxTimerValueTypingCompleted.Start();
+        }
+
+        private void uxButtonToggleMask_Click(object sender, EventArgs e)
+        {
+            if (this._isMasked)
+            {
+                this._isMasked = false;
+                this.uxTextBoxValue.Text = this._maskedRealValue;
+                this._maskedRealValue = string.Empty;
+                this.uxButtonToggleMask.Text = "Hide";
+            }
+            else
+            {
+                this._maskedRealValue = this.uxTextBoxValue.Text;
+                this._isMasked = true;
+                this.uxTextBoxValue.Text = new string('*', this._maskedRealValue.Length);
+                this.uxButtonToggleMask.Text = "Show";
+            }
         }
 
         private void SecretObject_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Vault/Explorer/Dialogs/Settings/SettingsDialog.cs
+++ b/Vault/Explorer/Dialogs/Settings/SettingsDialog.cs
@@ -75,8 +75,8 @@ namespace Microsoft.Vault.Explorer.Dialogs.Settings
             StringBuilder sb = new StringBuilder();
             sb.AppendLine(Utils.GetFileVersionString(string.Format("{0} version: ", Globals.AppName), Path.GetFileName(Application.ExecutablePath), string.Format(" ({0})", Environment.Is64BitProcess ? "x64" : "x86")));
             sb.AppendLine(string.Format(".NET framework version: {0}", Environment.Version));
-            sb.AppendLine(Utils.GetFileVersionString("Microsoft.Azure.KeyVault.dll version: ", "Microsoft.Azure.KeyVault.dll"));
-            sb.AppendLine(Utils.GetFileVersionString("Microsoft.Azure.Management.KeyVault.dll version: ", "Microsoft.Azure.Management.KeyVault.dll"));
+            sb.AppendLine(Utils.GetFileVersionString("Azure.Security.KeyVault.Secrets.dll version: ", "Azure.Security.KeyVault.Secrets.dll"));
+            sb.AppendLine(Utils.GetFileVersionString("Azure.ResourceManager.KeyVault.dll version: ", "Azure.ResourceManager.KeyVault.dll"));
             return sb.ToString();
         }
 

--- a/Vault/Explorer/Dialogs/Subscriptions/AccessPolicyEntryItem.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/AccessPolicyEntryItem.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
     [Editor(typeof(ExpandableObjectConverter), typeof(UITypeEditor))]
     public class AccessPolicyEntryItem
     {
-        private static readonly string[] EmptyList = new string[] { };
         private readonly KeyVaultAccessPolicy _ape;
 
         public AccessPolicyEntryItem(int index, KeyVaultAccessPolicy ape)
@@ -28,13 +27,13 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
         public Guid ObjectId => Guid.Parse(this._ape.ObjectId);
 
         [Description("Permissions to keys")]
-        public string PermissionsToKeys => string.Join(",", this._ape.Permissions.Keys ?? (System.Collections.Generic.IList<IdentityAccessKeyPermission>)EmptyList);
+        public string PermissionsToKeys => string.Join(",", this._ape.Permissions?.Keys ?? Array.Empty<IdentityAccessKeyPermission>());
 
         [Description("Permissions to secrets")]
-        public string PermissionsToSecrets => string.Join(",", this._ape.Permissions.Secrets ?? (System.Collections.Generic.IList<IdentityAccessSecretPermission>)EmptyList);
+        public string PermissionsToSecrets => string.Join(",", this._ape.Permissions?.Secrets ?? Array.Empty<IdentityAccessSecretPermission>());
 
         [Description("Permissions to certificates")]
-        public string PermissionsToCertificates => string.Join(",", this._ape.Permissions.Certificates ?? (System.Collections.Generic.IList<IdentityAccessCertificatePermission>)EmptyList);
+        public string PermissionsToCertificates => string.Join(",", this._ape.Permissions?.Certificates ?? Array.Empty<IdentityAccessCertificatePermission>());
 
         [Description("Tenant ID of the principal")]
         public Guid TenantId => this._ape.TenantId;

--- a/Vault/Explorer/Dialogs/Subscriptions/AccessPolicyEntryItem.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/AccessPolicyEntryItem.cs
@@ -3,16 +3,16 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
     using System;
     using System.ComponentModel;
     using System.Drawing.Design;
-    using Microsoft.Azure.Management.KeyVault.Models;
+    using Azure.ResourceManager.KeyVault.Models;
     using Newtonsoft.Json;
 
     [Editor(typeof(ExpandableObjectConverter), typeof(UITypeEditor))]
     public class AccessPolicyEntryItem
     {
         private static readonly string[] EmptyList = new string[] { };
-        private readonly AccessPolicyEntry _ape;
+        private readonly KeyVaultAccessPolicy _ape;
 
-        public AccessPolicyEntryItem(int index, AccessPolicyEntry ape)
+        public AccessPolicyEntryItem(int index, KeyVaultAccessPolicy ape)
         {
             this.Index = index;
             this._ape = ape;
@@ -28,13 +28,13 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
         public Guid ObjectId => Guid.Parse(this._ape.ObjectId);
 
         [Description("Permissions to keys")]
-        public string PermissionsToKeys => string.Join(",", this._ape.Permissions.Keys ?? EmptyList);
+        public string PermissionsToKeys => string.Join(",", this._ape.Permissions.Keys ?? (System.Collections.Generic.IList<IdentityAccessKeyPermission>)EmptyList);
 
         [Description("Permissions to secrets")]
-        public string PermissionsToSecrets => string.Join(",", this._ape.Permissions.Secrets ?? EmptyList);
+        public string PermissionsToSecrets => string.Join(",", this._ape.Permissions.Secrets ?? (System.Collections.Generic.IList<IdentityAccessSecretPermission>)EmptyList);
 
         [Description("Permissions to certificates")]
-        public string PermissionsToCertificates => string.Join(",", this._ape.Permissions.Certificates ?? EmptyList);
+        public string PermissionsToCertificates => string.Join(",", this._ape.Permissions.Certificates ?? (System.Collections.Generic.IList<IdentityAccessCertificatePermission>)EmptyList);
 
         [Description("Tenant ID of the principal")]
         public Guid TenantId => this._ape.TenantId;

--- a/Vault/Explorer/Dialogs/Subscriptions/AccountItem.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/AccountItem.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             this.UserAlias = userAlias ?? Globals.DefaultUserName;
         }
 
-        public override string ToString() => $"{this.UserAlias}@{this.DomainHint}";
+        public override string ToString() => this.UserAlias.Contains("@") ? this.UserAlias : $"{this.UserAlias}@{this.DomainHint}";
     }
 }

--- a/Vault/Explorer/Dialogs/Subscriptions/ListViewItemVault.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/ListViewItemVault.cs
@@ -2,22 +2,23 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 {
     using System.Text.RegularExpressions;
     using System.Windows.Forms;
+    using Azure.ResourceManager.KeyVault;
 
     public class ListViewItemVault : ListViewItem
     {
         // https://azure.microsoft.com/en-us/documentation/articles/guidance-naming-conventions/
         private static readonly Regex s_resourceNameRegex = new Regex(@".*\/resourceGroups\/(?<GroupName>[a-zA-Z0-9_\-\.]{1,64})\/", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
-        public readonly Azure.Management.KeyVault.Models.Resource Vault;
+        public readonly KeyVaultResource Vault;
         public readonly string GroupName;
 
-        public ListViewItemVault(Azure.Management.KeyVault.Models.Resource vault) : base(vault.Name)
+        public ListViewItemVault(KeyVaultResource vault) : base(vault.Data.Name)
         {
             this.Vault = vault;
-            this.Name = vault.Name;
-            this.GroupName = s_resourceNameRegex.Match(vault.Id).Groups["GroupName"].Value;
+            this.Name = vault.Data.Name;
+            this.GroupName = s_resourceNameRegex.Match(vault.Id.ToString()).Groups["GroupName"].Value;
             this.SubItems.Add(this.GroupName);
-            this.ToolTipText = $"Location: {vault.Location}";
+            this.ToolTipText = $"Location: {vault.Data.Location}";
             this.ImageIndex = 1;
         }
     }

--- a/Vault/Explorer/Dialogs/Subscriptions/PropertyObjectVault.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/PropertyObjectVault.cs
@@ -2,24 +2,24 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 {
     using System;
     using System.ComponentModel;
-    using Microsoft.Azure.Management.KeyVault.Models;
+    using Azure.ResourceManager.KeyVault;
     using Microsoft.Vault.Explorer.Model.Collections;
 
     public class PropertyObjectVault
     {
         private readonly Subscription _subscription;
         private readonly string _resourceGroupName;
-        private readonly Vault _vault;
+        private readonly KeyVaultResource _vault;
 
-        public PropertyObjectVault(Subscription s, string resourceGroupName, Vault vault)
+        public PropertyObjectVault(Subscription s, string resourceGroupName, KeyVaultResource vault)
         {
             this._subscription = s;
             this._resourceGroupName = resourceGroupName;
             this._vault = vault;
             this.Tags = new ObservableTagItemsCollection();
-            if (null != this._vault.Tags)
+            if (null != this._vault.Data.Tags)
             {
-                foreach (var kvp in this._vault.Tags)
+                foreach (var kvp in this._vault.Data.Tags)
                 {
                     this.Tags.Add(new TagItem(kvp));
                 }
@@ -27,7 +27,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 
             this.AccessPolicies = new ObservableAccessPoliciesCollection();
             int i = -1;
-            foreach (var ape in this._vault.Properties.AccessPolicies)
+            foreach (var ape in this._vault.Data.Properties.AccessPolicies)
             {
                 this.AccessPolicies.Add(new AccessPolicyEntryItem(++i, ape));
             }
@@ -35,15 +35,15 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 
         [DisplayName("Name")]
         [ReadOnly(true)]
-        public string Name => this._vault.Name;
+        public string Name => this._vault.Data.Name;
 
         [DisplayName("Location")]
         [ReadOnly(true)]
-        public string Location => this._vault.Location;
+        public string Location => this._vault.Data.Location.ToString();
 
         [DisplayName("Uri")]
         [ReadOnly(true)]
-        public string Uri => this._vault.Properties.VaultUri;
+        public string Uri => this._vault.Data.Properties.VaultUri?.ToString();
 
         [DisplayName("Subscription Name")]
         [ReadOnly(true)]
@@ -63,7 +63,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 
         [DisplayName("Sku")]
         [ReadOnly(true)]
-        public SkuName Sku => this._vault.Properties.Sku.Name;
+        public string Sku => this._vault.Data.Properties.Sku.Name.ToString();
 
         [DisplayName("Access Policies")]
         [ReadOnly(true)]

--- a/Vault/Explorer/Dialogs/Subscriptions/StaticTokenCredential.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/StaticTokenCredential.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core;
+
+    /// <summary>
+    /// A <see cref="TokenCredential"/> that wraps a pre-acquired access token for use
+    /// with ARM clients in the subscriptions manager dialog.
+    /// </summary>
+    internal sealed class StaticTokenCredential : TokenCredential
+    {
+        private readonly AccessToken _token;
+
+        internal StaticTokenCredential(string accessToken, DateTimeOffset expiresOn)
+        {
+            _token = new AccessToken(accessToken, expiresOn);
+        }
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => _token;
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new ValueTask<AccessToken>(_token);
+    }
+}

--- a/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.Designer.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.Designer.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             System.Windows.Forms.ColumnHeader columnHeader1;
             System.Windows.Forms.ColumnHeader columnHeader2;
             System.Windows.Forms.ToolStripLabel toolStripLabel1;
+            System.Windows.Forms.ToolStripLabel toolStripLabel2;
             System.Windows.Forms.SplitContainer splitContainer1;
             System.Windows.Forms.SplitContainer splitContainer2;
             System.Windows.Forms.ImageList imageList1;
@@ -43,6 +44,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             this.uxListViewVaults = new System.Windows.Forms.ListView();
             this.uxPropertyGridVault = new System.Windows.Forms.PropertyGrid();
             this.uxComboBoxAccounts = new System.Windows.Forms.ToolStripComboBox();
+            this.uxComboBoxTenants = new System.Windows.Forms.ToolStripComboBox();
             this.uxButtonCancelOperation = new System.Windows.Forms.ToolStripButton();
             this.uxProgressBar = new System.Windows.Forms.ToolStripProgressBar();
             this.uxStatusLabel = new System.Windows.Forms.ToolStripLabel();
@@ -53,6 +55,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
+            toolStripLabel2 = new System.Windows.Forms.ToolStripLabel();
             splitContainer1 = new System.Windows.Forms.SplitContainer();
             splitContainer2 = new System.Windows.Forms.SplitContainer();
             imageList1 = new System.Windows.Forms.ImageList(this.components);
@@ -93,6 +96,12 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             toolStripLabel1.Name = "toolStripLabel1";
             toolStripLabel1.Size = new System.Drawing.Size(63, 25);
             toolStripLabel1.Text = "Account";
+            // 
+            // toolStripLabel2
+            // 
+            toolStripLabel2.Name = "toolStripLabel2";
+            toolStripLabel2.Size = new System.Drawing.Size(51, 25);
+            toolStripLabel2.Text = "Tenant";
             // 
             // splitContainer1
             // 
@@ -204,6 +213,8 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             toolStripLabel1,
             this.uxComboBoxAccounts,
+            toolStripLabel2,
+            this.uxComboBoxTenants,
             this.uxButtonCancelOperation,
             this.uxProgressBar,
             this.uxStatusLabel});
@@ -220,6 +231,14 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             this.uxComboBoxAccounts.Name = "uxComboBoxAccounts";
             this.uxComboBoxAccounts.Size = new System.Drawing.Size(351, 28);
             this.uxComboBoxAccounts.SelectedIndexChanged += new System.EventHandler(this.uxComboBoxAccounts_SelectedIndexChanged);
+            // 
+            // uxComboBoxTenants
+            // 
+            this.uxComboBoxTenants.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.uxComboBoxTenants.DropDownWidth = 260;
+            this.uxComboBoxTenants.Name = "uxComboBoxTenants";
+            this.uxComboBoxTenants.Size = new System.Drawing.Size(260, 28);
+            this.uxComboBoxTenants.SelectedIndexChanged += new System.EventHandler(this.uxComboBoxTenants_SelectedIndexChanged);
             // 
             // uxButtonCancelOperation
             // 
@@ -315,6 +334,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
         private System.Windows.Forms.Button uxButtonCancel;
         private System.Windows.Forms.Button uxButtonOK;
         private System.Windows.Forms.ToolStripComboBox uxComboBoxAccounts;
+        private System.Windows.Forms.ToolStripComboBox uxComboBoxTenants;
         private System.Windows.Forms.ToolStripProgressBar uxProgressBar;
         private System.Windows.Forms.ToolStripButton uxButtonCancelOperation;
         private System.Windows.Forms.ToolStripLabel uxStatusLabel;

--- a/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.Designer.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.Designer.cs
@@ -301,6 +301,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.uxButtonCancel;
             this.ClientSize = new System.Drawing.Size(829, 759);
+            this.MinimumSize = new System.Drawing.Size(640, 680);
             this.Controls.Add(splitContainer1);
             this.Controls.Add(toolStrip1);
             this.Controls.Add(this.uxButtonCancel);

--- a/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 {
     using System;
+    using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
@@ -23,6 +24,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
         private const string ApiVersion = "api-version=2016-07-01";
         private const string ManagmentEndpoint = "https://management.azure.com/";
         private const string AddAccountText = "Add New Account";
+        private const string SelectAccountPrompt = "Select an account or add new...";
 
         private AccountItem _currentAccountItem;
         private AuthenticationResult _currentAuthResult;
@@ -61,7 +63,12 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             {
                 // No pre-configured accounts, don't auto-select anything
                 this.uxComboBoxAccounts.SelectedIndex = -1;
-                this.uxComboBoxAccounts.Text = "Select an account or add new...";
+                this.uxComboBoxAccounts.Text = SelectAccountPrompt;
+                MessageBox.Show(
+                    "No saved accounts were found.\n\nSelect 'Add New Account' to sign in, then choose a subscription and vault.",
+                    "Subscriptions onboarding",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
             }
         }
 
@@ -100,17 +107,39 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 
             using (var op = this.NewUxOperationWithProgress(this.uxComboBoxAccounts))
             {
-                this._httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this._currentAuthResult.AccessToken);
-                var hrm = await this._httpClient.GetAsync($"{ManagmentEndpoint}subscriptions?{ApiVersion}", op.CancellationToken);
-                var json = await hrm.Content.ReadAsStringAsync();
-                var subs = JsonConvert.DeserializeObject<SubscriptionsResponse>(json);
-
-                this.uxListViewSubscriptions.Items.Clear();
-                this.uxListViewVaults.Items.Clear();
-                this.uxPropertyGridVault.SelectedObject = null;
-                foreach (var s in subs.Subscriptions)
+                try
                 {
-                    this.uxListViewSubscriptions.Items.Add(new ListViewItemSubscription(s));
+                    this._httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this._currentAuthResult.AccessToken);
+                    var hrm = await this._httpClient.GetAsync($"{ManagmentEndpoint}subscriptions?{ApiVersion}", op.CancellationToken);
+                    var json = await hrm.Content.ReadAsStringAsync();
+                    hrm.EnsureSuccessStatusCode();
+                    var subs = JsonConvert.DeserializeObject<SubscriptionsResponse>(json);
+
+                    this.uxListViewSubscriptions.Items.Clear();
+                    this.uxListViewVaults.Items.Clear();
+                    this.uxPropertyGridVault.SelectedObject = null;
+                    if (subs?.Subscriptions == null || subs.Subscriptions.Length == 0)
+                    {
+                        MessageBox.Show(
+                            "No subscriptions were found for this account.\n\nConfirm the account has access and try another account or tenant.",
+                            "No subscriptions found",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Warning);
+                        return;
+                    }
+
+                    foreach (var s in subs.Subscriptions)
+                    {
+                        this.uxListViewSubscriptions.Items.Add(new ListViewItemSubscription(s));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        $"Failed to load subscriptions: {ex.Message}",
+                        "Subscriptions error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
                 }
             }
         }
@@ -120,6 +149,12 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             ListViewItemSubscription s = this.uxListViewSubscriptions.SelectedItems.Count > 0 ? (ListViewItemSubscription)this.uxListViewSubscriptions.SelectedItems[0] : null;
             if (null == s)
             {
+                return;
+            }
+
+            if (this._currentAuthResult == null)
+            {
+                MessageBox.Show("Please sign in first by selecting an account.", "Not signed in", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
 
@@ -179,11 +214,24 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
                 // Get new user account and add it to default settings
                 string userAccountName = this._currentAuthResult.Account.Username;
                 string[] userLogin = userAccountName.Split('@');
+                if (userLogin.Length != 2)
+                {
+                    MessageBox.Show("Could not parse signed-in account name. Please sign in with a standard UPN account.", "Unsupported account format", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
                 this._currentAccountItem.UserAlias = userLogin[0];
                 this._currentAccountItem.DomainHint = userLogin[1];
                 if (!Settings.Default.AddUserAccountName(userAccountName))
                 {
-                    MessageBox.Show($"The user name {userAccountName} already exists.", "Username exists", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    AccountItem existing = this.uxComboBoxAccounts.Items.OfType<AccountItem>()
+                        .FirstOrDefault(a => string.Equals(a.ToString(), userAccountName, StringComparison.OrdinalIgnoreCase));
+                    if (existing != null)
+                    {
+                        this.uxComboBoxAccounts.SelectedItem = existing;
+                    }
+
+                    MessageBox.Show($"The account {userAccountName} is already configured and has been selected.", "Account already exists", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     return;
                 }
 
@@ -192,12 +240,23 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
                 this.uxComboBoxAccounts.Items.Insert(0, newAccountItem);
                 this.uxComboBoxAccounts.SelectedIndex = 0;
             }
+            catch (MsalException ex)
+            {
+                MessageBox.Show(
+                    $"Authentication failed: {ex.Message}\n\nTip: close existing browser sign-in windows and try 'Add New Account' again.",
+                    "Authentication Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                // Reset selection to allow user to try again
+                this.uxComboBoxAccounts.SelectedIndex = -1;
+                this.uxComboBoxAccounts.Text = SelectAccountPrompt;
+            }
             catch (Exception ex)
             {
                 MessageBox.Show($"Authentication failed: {ex.Message}", "Authentication Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 // Reset selection to allow user to try again
                 this.uxComboBoxAccounts.SelectedIndex = -1;
-                this.uxComboBoxAccounts.Text = "Select an account or add new...";
+                this.uxComboBoxAccounts.Text = SelectAccountPrompt;
             }
         }
 

--- a/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
         private KeyVaultManagementClient _currentKeyVaultMgmtClient;
         private readonly HttpClient _httpClient;
         private bool _suppressTenantSelectionEvent;
+        private bool _showOnboardingOnLoad;
 
         public VaultAlias CurrentVaultAlias { get; private set; }
 
@@ -69,10 +70,23 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             }
             else
             {
-                // No pre-configured accounts, don't auto-select anything
+                // No pre-configured accounts — defer the onboarding prompt until after the form is shown
+                // so the form renders fully before any MessageBox appears.
                 this.uxComboBoxAccounts.SelectedIndex = -1;
                 this.uxComboBoxAccounts.Text = SelectAccountPrompt;
+                this._showOnboardingOnLoad = true;
+            }
+
+            this.Shown += this.SubscriptionsManagerDialog_Shown;
+        }
+
+        private void SubscriptionsManagerDialog_Shown(object sender, EventArgs e)
+        {
+            if (this._showOnboardingOnLoad)
+            {
+                this._showOnboardingOnLoad = false;
                 MessageBox.Show(
+                    this,
                     "No saved accounts were found.\n\nSelect 'Add New Account' to sign in, then choose a subscription and vault.",
                     "Subscriptions onboarding",
                     MessageBoxButtons.OK,
@@ -260,6 +274,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             ListViewItemSubscription s = this.uxListViewSubscriptions.SelectedItems.Count > 0 ? (ListViewItemSubscription)this.uxListViewSubscriptions.SelectedItems[0] : null;
             ListViewItemVault v = this.uxListViewVaults.SelectedItems.Count > 0 ? (ListViewItemVault)this.uxListViewVaults.SelectedItems[0] : null;
             this.uxButtonOK.Enabled = false;
+            this.CurrentVaultAlias = null;
             if (null == s || null == v)
             {
                 return;
@@ -267,16 +282,28 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 
             using (var op = this.NewUxOperationWithProgress(this.uxComboBoxAccounts))
             {
-                var vault = await this._currentKeyVaultMgmtClient.Vaults.GetAsync(v.GroupName, v.Name);
-                this.uxPropertyGridVault.SelectedObject = new PropertyObjectVault(s.Subscription, v.GroupName, vault);
-                this.uxButtonOK.Enabled = true;
-
-                this.CurrentVaultAlias = new VaultAlias(v.Name, new[] { v.Name }, new[] { "Custom" })
+                try
                 {
-                    DomainHint = this._currentAccountItem.DomainHint,
-                    UserAlias = this._currentAccountItem.UserAlias,
-                    IsNew = true, // Mark as new since it's being added from SubscriptionsManagerDialog
-                };
+                    var vault = await this._currentKeyVaultMgmtClient.Vaults.GetAsync(v.GroupName, v.Name);
+                    this.uxPropertyGridVault.SelectedObject = new PropertyObjectVault(s.Subscription, v.GroupName, vault);
+                    this.CurrentVaultAlias = new VaultAlias(v.Name, new[] { v.Name }, new[] { "Custom" })
+                    {
+                        DomainHint = this._currentAccountItem.DomainHint,
+                        UserAlias = this._currentAccountItem.UserAlias,
+                        IsNew = true,
+                    };
+                    this.uxButtonOK.Enabled = true;
+                }
+                catch (Exception ex)
+                {
+                    this.uxPropertyGridVault.SelectedObject = null;
+                    MessageBox.Show(
+                        this,
+                        $"Failed to load vault details: {ex.Message}\n\nSelect a different vault or try again.",
+                        "Vault load error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                }
             }
         }
 

--- a/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Headers;
@@ -15,6 +16,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
     using Microsoft.Vault.Explorer.Common;
     using Microsoft.Vault.Explorer.Model.Files.Aliases;
     using Microsoft.Vault.Library;
+    using Newtonsoft.Json.Linq;
     using Newtonsoft.Json;
     using Settings = Microsoft.Vault.Explorer.Settings;
     using Utils = Microsoft.Vault.Explorer.Common.Utils;
@@ -23,13 +25,16 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
     {
         private const string ApiVersion = "api-version=2016-07-01";
         private const string ManagmentEndpoint = "https://management.azure.com/";
+        private const string TenantsApiVersion = "api-version=2020-01-01";
         private const string AddAccountText = "Add New Account";
         private const string SelectAccountPrompt = "Select an account or add new...";
+        private const string SelectTenantPrompt = "Select a tenant...";
 
         private AccountItem _currentAccountItem;
         private AuthenticationResult _currentAuthResult;
         private KeyVaultManagementClient _currentKeyVaultMgmtClient;
         private readonly HttpClient _httpClient;
+        private bool _suppressTenantSelectionEvent;
 
         public VaultAlias CurrentVaultAlias { get; private set; }
 
@@ -53,6 +58,9 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             }
 
             this.uxComboBoxAccounts.Items.Add(AddAccountText);
+            this.uxComboBoxTenants.Items.Clear();
+            this.uxComboBoxTenants.Items.Add(SelectTenantPrompt);
+            this.uxComboBoxTenants.SelectedIndex = 0;
 
             // Only auto-select if we have pre-configured accounts, otherwise let user choose
             if (hasPreConfiguredAccounts)
@@ -91,7 +99,12 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
                     await this.GetAuthenticationTokenAsync();
                     if (this._currentAuthResult.Account != null)
                     {
-                        this._currentAccountItem.UserAlias = this._currentAuthResult.Account.Username.Split('@')[0];
+                        this._currentAccountItem.UserAlias = this._currentAuthResult.Account.Username;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(this._currentAuthResult?.TenantId))
+                    {
+                        this._currentAccountItem.DomainHint = this._currentAuthResult.TenantId;
                     }
 
                     break;
@@ -105,7 +118,61 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
                 return;
             }
 
-            using (var op = this.NewUxOperationWithProgress(this.uxComboBoxAccounts))
+            await this.LoadTenantsAsync();
+            await this.LoadSubscriptionsAsync();
+        }
+
+        private async Task LoadTenantsAsync()
+        {
+            using (var op = this.NewUxOperationWithProgress(this.uxComboBoxAccounts, this.uxComboBoxTenants))
+            {
+                try
+                {
+                    this._httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this._currentAuthResult.AccessToken);
+                    var hrm = await this._httpClient.GetAsync($"{ManagmentEndpoint}tenants?{TenantsApiVersion}", op.CancellationToken);
+                    var json = await hrm.Content.ReadAsStringAsync();
+                    hrm.EnsureSuccessStatusCode();
+                    JObject payload = JObject.Parse(json);
+                    List<TenantItem> tenants = payload["value"]?
+                        .Select(v => new TenantItem((string)v["tenantId"], (string)v["defaultDomain"]))
+                        .Where(t => !string.IsNullOrWhiteSpace(t.TenantId))
+                        .ToList() ?? new List<TenantItem>();
+
+                    if (tenants.Count == 0)
+                    {
+                        return;
+                    }
+
+                    this._suppressTenantSelectionEvent = true;
+                    this.uxComboBoxTenants.Items.Clear();
+                    foreach (TenantItem tenant in tenants)
+                    {
+                        this.uxComboBoxTenants.Items.Add(tenant);
+                    }
+
+                    TenantItem selectedTenant = tenants.FirstOrDefault(t => string.Equals(t.TenantId, this._currentAuthResult.TenantId, StringComparison.OrdinalIgnoreCase))
+                                               ?? tenants.FirstOrDefault(t => string.Equals(t.TenantId, this._currentAccountItem.DomainHint, StringComparison.OrdinalIgnoreCase))
+                                               ?? tenants[0];
+                    this.uxComboBoxTenants.SelectedItem = selectedTenant;
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        $"Failed to load subscriptions: {ex.Message}",
+                        "Subscriptions error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+                finally
+                {
+                    this._suppressTenantSelectionEvent = false;
+                }
+            }
+        }
+
+        private async Task LoadSubscriptionsAsync()
+        {
+            using (var op = this.NewUxOperationWithProgress(this.uxComboBoxAccounts, this.uxComboBoxTenants))
             {
                 try
                 {
@@ -142,6 +209,23 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
                         MessageBoxIcon.Error);
                 }
             }
+        }
+
+        private async void uxComboBoxTenants_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (this._suppressTenantSelectionEvent || this.uxComboBoxTenants.SelectedItem is not TenantItem tenant)
+            {
+                return;
+            }
+
+            if (this._currentAccountItem == null || string.Equals(this._currentAccountItem.DomainHint, tenant.TenantId, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            this._currentAccountItem.DomainHint = tenant.TenantId;
+            await this.GetAuthenticationTokenAsync();
+            await this.LoadSubscriptionsAsync();
         }
 
         private async void uxListViewSubscriptions_SelectedIndexChanged(object sender, EventArgs e)
@@ -220,8 +304,8 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
                     return;
                 }
 
-                this._currentAccountItem.UserAlias = userLogin[0];
-                this._currentAccountItem.DomainHint = userLogin[1];
+                this._currentAccountItem.UserAlias = userAccountName;
+                this._currentAccountItem.DomainHint = string.IsNullOrWhiteSpace(this._currentAuthResult.TenantId) ? userLogin[1] : this._currentAuthResult.TenantId;
                 if (!Settings.Default.AddUserAccountName(userAccountName))
                 {
                     AccountItem existing = this.uxComboBoxAccounts.Items.OfType<AccountItem>()
@@ -266,6 +350,20 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             VaultAccessUserInteractive vaui = new VaultAccessUserInteractive(this._currentAccountItem.DomainHint, this._currentAccountItem.UserAlias);
             string[] scopes = VaultAccess.ConvertResourceToScopes(ManagmentEndpoint);
             this._currentAuthResult = await vaui.AcquireTokenAsync(scopes, this._currentAccountItem.UserAlias);
+        }
+
+        private sealed class TenantItem
+        {
+            public string TenantId { get; }
+            public string Domain { get; }
+
+            public TenantItem(string tenantId, string domain)
+            {
+                this.TenantId = tenantId;
+                this.Domain = domain;
+            }
+
+            public override string ToString() => string.IsNullOrWhiteSpace(this.Domain) ? this.TenantId : $"{this.Domain} ({this.TenantId})";
         }
     }
 }

--- a/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
     using System.Windows.Forms;
-    using Microsoft.Azure.Management.KeyVault;
+    using Azure.ResourceManager;
+    using Azure.ResourceManager.KeyVault;
     using Microsoft.Identity.Client;
-    using Microsoft.Rest;
     using Microsoft.Vault.Explorer.Common;
     using Microsoft.Vault.Explorer.Model.Files.Aliases;
     using Microsoft.Vault.Library;
@@ -32,7 +32,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 
         private AccountItem _currentAccountItem;
         private AuthenticationResult _currentAuthResult;
-        private KeyVaultManagementClient _currentKeyVaultMgmtClient;
+        private ArmClient _currentArmClient;
         private readonly HttpClient _httpClient;
         private bool _suppressTenantSelectionEvent;
         private bool _showOnboardingOnLoad;
@@ -258,11 +258,12 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
 
             using (var op = this.NewUxOperationWithProgress(this.uxComboBoxAccounts))
             {
-                var tvcc = new TokenCredentials(this._currentAuthResult.AccessToken);
-                this._currentKeyVaultMgmtClient = new KeyVaultManagementClient(tvcc) { SubscriptionId = s.Subscription.SubscriptionId.ToString() };
-                var vaults = await this._currentKeyVaultMgmtClient.Vaults.ListAsync(null, op.CancellationToken);
+                var cred = new StaticTokenCredential(this._currentAuthResult.AccessToken, this._currentAuthResult.ExpiresOn);
+                this._currentArmClient = new ArmClient(cred, s.Subscription.SubscriptionId.ToString());
+                var subscriptionResource = this._currentArmClient.GetSubscriptionResource(
+                    SubscriptionResource.CreateResourceIdentifier(s.Subscription.SubscriptionId.ToString()));
                 this.uxListViewVaults.Items.Clear();
-                foreach (var v in vaults)
+                await foreach (var v in subscriptionResource.GetKeyVaultsAsync(cancellationToken: op.CancellationToken))
                 {
                     this.uxListViewVaults.Items.Add(new ListViewItemVault(v));
                 }
@@ -284,7 +285,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
             {
                 try
                 {
-                    var vault = await this._currentKeyVaultMgmtClient.Vaults.GetAsync(v.GroupName, v.Name);
+                    var vault = (await v.Vault.GetAsync(op.CancellationToken)).Value;
                     this.uxPropertyGridVault.SelectedObject = new PropertyObjectVault(s.Subscription, v.GroupName, vault);
                     this.CurrentVaultAlias = new VaultAlias(v.Name, new[] { v.Name }, new[] { "Custom" })
                     {

--- a/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
+++ b/Vault/Explorer/Dialogs/Subscriptions/SubscriptionsManagerDialog.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
                     hrm.EnsureSuccessStatusCode();
                     JObject payload = JObject.Parse(json);
                     List<TenantItem> tenants = payload["value"]?
-                        .Select(v => new TenantItem((string)v["tenantId"], (string)v["defaultDomain"]))
+                        .Select(v => new TenantItem((string)v["tenantId"], (string)v["displayName"], (string)v["defaultDomain"]))
                         .Where(t => !string.IsNullOrWhiteSpace(t.TenantId))
                         .ToList() ?? new List<TenantItem>();
 
@@ -158,8 +158,8 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
                 catch (Exception ex)
                 {
                     MessageBox.Show(
-                        $"Failed to load subscriptions: {ex.Message}",
-                        "Subscriptions error",
+                        $"Failed to load tenants: {ex.Message}",
+                        "Tenant load error",
                         MessageBoxButtons.OK,
                         MessageBoxIcon.Error);
                 }
@@ -355,15 +355,21 @@ namespace Microsoft.Vault.Explorer.Dialogs.Subscriptions
         private sealed class TenantItem
         {
             public string TenantId { get; }
+            public string DisplayName { get; }
             public string Domain { get; }
 
-            public TenantItem(string tenantId, string domain)
+            public TenantItem(string tenantId, string displayName, string domain)
             {
                 this.TenantId = tenantId;
+                this.DisplayName = displayName;
                 this.Domain = domain;
             }
 
-            public override string ToString() => string.IsNullOrWhiteSpace(this.Domain) ? this.TenantId : $"{this.Domain} ({this.TenantId})";
+            public override string ToString()
+            {
+                string name = !string.IsNullOrWhiteSpace(this.DisplayName) ? this.DisplayName : this.Domain;
+                return string.IsNullOrWhiteSpace(name) ? this.TenantId : $"{name} ({this.TenantId})";
+            }
         }
     }
 }

--- a/Vault/Explorer/Globals.cs
+++ b/Vault/Explorer/Globals.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Vault.Explorer
 
         public const string AppName = "Azure Key Vault Explorer";
 
-        public const string OnlineActivationUri = "https://alta01.github.io/AzureKeyVaultExplorer/VaultExplorer.application";
-        public const string GitHubUrl = "https://github.com/alta01/AzureKeyVaultExplorer";
-        public const string GitHubIssuesUrl = "https://github.com/alta01/AzureKeyVaultExplorer/issues";
-        public const string ActivationUrl = "https://alta01.github.io/AzureKeyVaultExplorer/VaultExplorer.application";
+        public const string OnlineActivationUri = "https://reysic.github.io/AzureKeyVaultExplorer/VaultExplorer.application";
+        public const string GitHubUrl = "https://github.com/reysic/AzureKeyVaultExplorer";
+        public const string GitHubIssuesUrl = "https://github.com/reysic/AzureKeyVaultExplorer/issues";
+        public const string ActivationUrl = "https://reysic.github.io/AzureKeyVaultExplorer/VaultExplorer.application";
 
         public static string DefaultUserName = Environment.UserName;
     }

--- a/Vault/Explorer/Globals.cs
+++ b/Vault/Explorer/Globals.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Vault.Explorer
 
         public const string AppName = "Azure Key Vault Explorer";
 
-        public const string OnlineActivationUri = "https://reysic.github.io/AzureKeyVaultExplorer/VaultExplorer.application";
-        public const string GitHubUrl = "https://github.com/reysic/AzureKeyVaultExplorer";
-        public const string GitHubIssuesUrl = "https://github.com/reysic/AzureKeyVaultExplorer/issues";
-        public const string ActivationUrl = "https://reysic.github.io/AzureKeyVaultExplorer/VaultExplorer.application";
+        public const string OnlineActivationUri = "https://alta01.github.io/AzureKeyVaultExplorer/VaultExplorer.application";
+        public const string GitHubUrl = "https://github.com/alta01/AzureKeyVaultExplorer";
+        public const string GitHubIssuesUrl = "https://github.com/alta01/AzureKeyVaultExplorer/issues";
+        public const string ActivationUrl = "https://alta01.github.io/AzureKeyVaultExplorer/VaultExplorer.application";
 
         public static string DefaultUserName = Environment.UserName;
     }

--- a/Vault/Explorer/MainForm.Designer.cs
+++ b/Vault/Explorer/MainForm.Designer.cs
@@ -200,6 +200,14 @@ namespace Microsoft.Vault.Explorer
             this.uxButtonCopyLink = new System.Windows.Forms.ToolStripMenuItem();
             this.uxButtonSave = new System.Windows.Forms.ToolStripMenuItem();
             this.uxButtonExportToTsv = new System.Windows.Forms.ToolStripMenuItem();
+            this.uxButtonCopyAsEnvVar = new System.Windows.Forms.ToolStripMenuItem();
+            this.uxButtonCopyAsDockerEnv = new System.Windows.Forms.ToolStripMenuItem();
+            this.uxButtonCopyAsK8sYaml = new System.Windows.Forms.ToolStripMenuItem();
+            this.uxButtonCopyName = new System.Windows.Forms.ToolStripMenuItem();
+            this.uxMenuItemCopyAsEnvVar = new System.Windows.Forms.ToolStripMenuItem();
+            this.uxMenuItemCopyAsDockerEnv = new System.Windows.Forms.ToolStripMenuItem();
+            this.uxMenuItemCopyAsK8sYaml = new System.Windows.Forms.ToolStripMenuItem();
+            this.uxMenuItemCopyName = new System.Windows.Forms.ToolStripMenuItem();
             this.uxButtonFavorite = new System.Windows.Forms.ToolStripButton();
             this.uxButtonSettings = new System.Windows.Forms.ToolStripButton();
             this.uxButtonHelp = new System.Windows.Forms.ToolStripButton();
@@ -222,6 +230,8 @@ namespace Microsoft.Vault.Explorer
             toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             usStatusLabelSpring = new System.Windows.Forms.ToolStripStatusLabel();
             toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            System.Windows.Forms.ToolStripSeparator toolStripSeparatorCopyAs1 = new System.Windows.Forms.ToolStripSeparator();
+            System.Windows.Forms.ToolStripSeparator toolStripSeparatorCopyAs2 = new System.Windows.Forms.ToolStripSeparator();
             ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
             splitContainer1.Panel1.SuspendLayout();
             splitContainer1.Panel2.SuspendLayout();
@@ -663,7 +673,7 @@ namespace Microsoft.Vault.Explorer
             // 
             // uxMenuItemShare
             // 
-            this.uxMenuItemShare.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { this.uxMenuItemCopy, this.uxMenuItemCopyLink, this.uxMenuItemSave, toolStripMenuItem2, this.uxMenuItemExportToTsv });
+            this.uxMenuItemShare.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { this.uxMenuItemCopy, this.uxMenuItemCopyLink, this.uxMenuItemSave, toolStripMenuItem2, this.uxMenuItemExportToTsv, toolStripSeparatorCopyAs2, this.uxMenuItemCopyAsEnvVar, this.uxMenuItemCopyAsDockerEnv, this.uxMenuItemCopyAsK8sYaml, this.uxMenuItemCopyName });
             this.uxMenuItemShare.Enabled = false;
             this.uxMenuItemShare.Image = Properties.Resources.group;
             this.uxMenuItemShare.Name = "uxMenuItemShare";
@@ -712,7 +722,44 @@ namespace Microsoft.Vault.Explorer
             this.uxMenuItemExportToTsv.Text = "&Export to Tsv...";
             this.uxMenuItemExportToTsv.ToolTipText = "Export all or selected items to .tsv file";
             this.uxMenuItemExportToTsv.Click += this.uxButtonExportToTsv_Click;
-            // 
+            //
+            // uxMenuItemCopyAsEnvVar
+            //
+            this.uxMenuItemCopyAsEnvVar.Image = Properties.Resources.page_copy;
+            this.uxMenuItemCopyAsEnvVar.Name = "uxMenuItemCopyAsEnvVar";
+            this.uxMenuItemCopyAsEnvVar.Size = new System.Drawing.Size(251, 22);
+            this.uxMenuItemCopyAsEnvVar.Text = "Copy as &env var";
+            this.uxMenuItemCopyAsEnvVar.ToolTipText = "Copy as NAME=value env var";
+            this.uxMenuItemCopyAsEnvVar.Click += this.uxButtonCopyAsEnvVar_Click;
+            //
+            // uxMenuItemCopyAsDockerEnv
+            //
+            this.uxMenuItemCopyAsDockerEnv.Image = Properties.Resources.page_copy;
+            this.uxMenuItemCopyAsDockerEnv.Name = "uxMenuItemCopyAsDockerEnv";
+            this.uxMenuItemCopyAsDockerEnv.Size = new System.Drawing.Size(251, 22);
+            this.uxMenuItemCopyAsDockerEnv.Text = "Copy as &Docker --env";
+            this.uxMenuItemCopyAsDockerEnv.ToolTipText = "Copy as --env NAME=value for docker run";
+            this.uxMenuItemCopyAsDockerEnv.Click += this.uxButtonCopyAsDockerEnv_Click;
+            //
+            // uxMenuItemCopyAsK8sYaml
+            //
+            this.uxMenuItemCopyAsK8sYaml.Image = Properties.Resources.page_copy;
+            this.uxMenuItemCopyAsK8sYaml.Name = "uxMenuItemCopyAsK8sYaml";
+            this.uxMenuItemCopyAsK8sYaml.Size = new System.Drawing.Size(251, 22);
+            this.uxMenuItemCopyAsK8sYaml.Text = "Copy as &Kubernetes secret YAML";
+            this.uxMenuItemCopyAsK8sYaml.ToolTipText = "Copy as Kubernetes stringData secret YAML";
+            this.uxMenuItemCopyAsK8sYaml.Click += this.uxButtonCopyAsK8sYaml_Click;
+            //
+            // uxMenuItemCopyName
+            //
+            this.uxMenuItemCopyName.Image = Properties.Resources.page_copy;
+            this.uxMenuItemCopyName.Name = "uxMenuItemCopyName";
+            this.uxMenuItemCopyName.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.N;
+            this.uxMenuItemCopyName.Size = new System.Drawing.Size(251, 22);
+            this.uxMenuItemCopyName.Text = "Copy &name only";
+            this.uxMenuItemCopyName.ToolTipText = "Copy secret name to clipboard (no value)";
+            this.uxMenuItemCopyName.Click += this.uxButtonCopyName_Click;
+            //
             // uxMenuItemFavorite
             // 
             this.uxMenuItemFavorite.Enabled = false;
@@ -954,7 +1001,7 @@ namespace Microsoft.Vault.Explorer
             // 
             // uxButtonShare
             // 
-            this.uxButtonShare.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { this.uxButtonCopy, this.uxButtonCopyLink, this.uxButtonSave, toolStripMenuItem1, this.uxButtonExportToTsv });
+            this.uxButtonShare.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { this.uxButtonCopy, this.uxButtonCopyLink, this.uxButtonSave, toolStripMenuItem1, this.uxButtonExportToTsv, toolStripSeparatorCopyAs1, this.uxButtonCopyAsEnvVar, this.uxButtonCopyAsDockerEnv, this.uxButtonCopyAsK8sYaml, this.uxButtonCopyName });
             this.uxButtonShare.Enabled = false;
             this.uxButtonShare.Image = Properties.Resources.group;
             this.uxButtonShare.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -1000,7 +1047,43 @@ namespace Microsoft.Vault.Explorer
             this.uxButtonExportToTsv.Text = "&Export to Tsv...";
             this.uxButtonExportToTsv.ToolTipText = "Export all or selected items to .tsv file";
             this.uxButtonExportToTsv.Click += this.uxButtonExportToTsv_Click;
-            // 
+            //
+            // uxButtonCopyAsEnvVar
+            //
+            this.uxButtonCopyAsEnvVar.Image = Properties.Resources.page_copy;
+            this.uxButtonCopyAsEnvVar.Name = "uxButtonCopyAsEnvVar";
+            this.uxButtonCopyAsEnvVar.Size = new System.Drawing.Size(220, 22);
+            this.uxButtonCopyAsEnvVar.Text = "Copy as &env var";
+            this.uxButtonCopyAsEnvVar.ToolTipText = "Copy as NAME=value env var";
+            this.uxButtonCopyAsEnvVar.Click += this.uxButtonCopyAsEnvVar_Click;
+            //
+            // uxButtonCopyAsDockerEnv
+            //
+            this.uxButtonCopyAsDockerEnv.Image = Properties.Resources.page_copy;
+            this.uxButtonCopyAsDockerEnv.Name = "uxButtonCopyAsDockerEnv";
+            this.uxButtonCopyAsDockerEnv.Size = new System.Drawing.Size(220, 22);
+            this.uxButtonCopyAsDockerEnv.Text = "Copy as &Docker --env";
+            this.uxButtonCopyAsDockerEnv.ToolTipText = "Copy as --env NAME=value for docker run";
+            this.uxButtonCopyAsDockerEnv.Click += this.uxButtonCopyAsDockerEnv_Click;
+            //
+            // uxButtonCopyAsK8sYaml
+            //
+            this.uxButtonCopyAsK8sYaml.Image = Properties.Resources.page_copy;
+            this.uxButtonCopyAsK8sYaml.Name = "uxButtonCopyAsK8sYaml";
+            this.uxButtonCopyAsK8sYaml.Size = new System.Drawing.Size(220, 22);
+            this.uxButtonCopyAsK8sYaml.Text = "Copy as &Kubernetes secret YAML";
+            this.uxButtonCopyAsK8sYaml.ToolTipText = "Copy as Kubernetes stringData secret YAML";
+            this.uxButtonCopyAsK8sYaml.Click += this.uxButtonCopyAsK8sYaml_Click;
+            //
+            // uxButtonCopyName
+            //
+            this.uxButtonCopyName.Image = Properties.Resources.page_copy;
+            this.uxButtonCopyName.Name = "uxButtonCopyName";
+            this.uxButtonCopyName.Size = new System.Drawing.Size(220, 22);
+            this.uxButtonCopyName.Text = "Copy &name only";
+            this.uxButtonCopyName.ToolTipText = "Copy secret name to clipboard (no value)";
+            this.uxButtonCopyName.Click += this.uxButtonCopyName_Click;
+            //
             // uxButtonFavorite
             // 
             this.uxButtonFavorite.Enabled = false;
@@ -1214,6 +1297,14 @@ namespace Microsoft.Vault.Explorer
         private System.Windows.Forms.ToolStripMenuItem uxMenuItemSave;
         private System.Windows.Forms.ToolStripMenuItem uxButtonExportToTsv;
         private System.Windows.Forms.ToolStripMenuItem uxMenuItemExportToTsv;
+        private System.Windows.Forms.ToolStripMenuItem uxButtonCopyAsEnvVar;
+        private System.Windows.Forms.ToolStripMenuItem uxButtonCopyAsDockerEnv;
+        private System.Windows.Forms.ToolStripMenuItem uxButtonCopyAsK8sYaml;
+        private System.Windows.Forms.ToolStripMenuItem uxButtonCopyName;
+        private System.Windows.Forms.ToolStripMenuItem uxMenuItemCopyAsEnvVar;
+        private System.Windows.Forms.ToolStripMenuItem uxMenuItemCopyAsDockerEnv;
+        private System.Windows.Forms.ToolStripMenuItem uxMenuItemCopyAsK8sYaml;
+        private System.Windows.Forms.ToolStripMenuItem uxMenuItemCopyName;
     }
 }
 

--- a/Vault/Explorer/MainForm.cs
+++ b/Vault/Explorer/MainForm.cs
@@ -210,6 +210,16 @@ namespace Microsoft.Vault.Explorer
             {
                 foreach (var vault in newVaults)
                 {
+                    if (string.IsNullOrWhiteSpace(vault.UserAlias) || !vault.UserAlias.Contains("@"))
+                    {
+                        MessageBox.Show(
+                            $"Vault '{vault.VaultNames[0]}' was not saved because it is not bound to a specific signed-in account.\n\nUse 'Pick vault from subscription...' and sign in first.",
+                            "Account required",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Warning);
+                        return false;
+                    }
+
                     bool success = VaultConfigurationManager.AddVaultConfiguration(
                         vault.VaultNames[0], // vault name
                         vault.Alias, // alias name
@@ -365,7 +375,7 @@ namespace Microsoft.Vault.Explorer
         {
             this.CurrentVault = new Vault(Utils.FullPathToJsonFile(Settings.Default.VaultsJsonFileLocation), VaultAccessTypeEnum.ReadWrite, this.CurrentVaultAlias.VaultNames);
             // In case that subscription is chosen by the dialog, overwrite permissions taken from vaults.json
-            if (this.CurrentVaultAlias.UserAlias != null || this.CurrentVault.VaultsConfig.Count == 0)
+            if (!string.IsNullOrWhiteSpace(this.CurrentVaultAlias.UserAlias) || this.CurrentVault.VaultsConfig.Count == 0)
             {
                 this.CurrentVault.VaultsConfig[this.CurrentVaultAlias.VaultNames[0]] = new VaultAccessType(
                     new VaultAccess[] { new VaultAccessUserInteractive(this.CurrentVaultAlias.DomainHint, this.CurrentVaultAlias.UserAlias) },

--- a/Vault/Explorer/MainForm.cs
+++ b/Vault/Explorer/MainForm.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Vault.Explorer
     using System.Linq;
     using System.Security.Cryptography.X509Certificates;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Certificates;
+    using Azure.Security.KeyVault.Secrets;
     using Microsoft.Vault.Core;
     using Microsoft.Vault.Explorer.Common;
     using Microsoft.Vault.Explorer.Config;
@@ -445,8 +446,8 @@ namespace Microsoft.Vault.Explorer
                     this.uxListViewSecrets.BeginUpdate();
                     int s = 0, c = 0;
                     Action updateCount = () => this.uxStatusLabelSecertsCount.Text = $"{s + c} secrets"; // We use delegate and Invoke() below to execute on the thread that owns the control
-                    IEnumerable<SecretItem> secrets = Enumerable.Empty<SecretItem>();
-                    IEnumerable<CertificateItem> certificates = Enumerable.Empty<CertificateItem>();
+                    IEnumerable<SecretProperties> secrets = Enumerable.Empty<SecretProperties>();
+                    IEnumerable<CertificateProperties> certificates = Enumerable.Empty<CertificateProperties>();
                     await op.Invoke("access",
                         async () => // List Secrets
                         {

--- a/Vault/Explorer/MainForm.cs
+++ b/Vault/Explorer/MainForm.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Vault.Explorer
         private bool _keyDownOccured;
         private readonly ToolStripButton uxButtonCancel;
         private readonly Dictionary<string, VaultAlias> _tempVaultAliases; // Temporary picked VaultAliases via SubscriptionsManager
+        private string _titleBase = Globals.AppName;
         private const string AddNewVaultText = "How to add new vault here...";
         private const string PickVaultText = "Pick vault from subscription...";
 
@@ -115,6 +116,35 @@ namespace Microsoft.Vault.Explorer
         {
             base.OnShown(e);
             this.uxPropertyGridSecret.SetLabelColumnWidth(250);
+            this.RestoreLastVault();
+        }
+
+        private void RestoreLastVault()
+        {
+            if (this.CurrentVaultAlias != null)
+            {
+                return; // Already set via activation URI
+            }
+
+            string lastAlias = Settings.Default.LastUsedVaultAlias;
+            if (string.IsNullOrEmpty(lastAlias))
+            {
+                return;
+            }
+
+            this.uxComboBoxVaultAlias_DropDown(this, EventArgs.Empty); // Populate items
+            VaultAlias match = this.uxComboBoxVaultAlias.Items.OfType<VaultAlias>()
+                .FirstOrDefault(v => string.Equals(v.Alias, lastAlias, StringComparison.OrdinalIgnoreCase));
+            if (match == null)
+            {
+                return;
+            }
+
+            this.uxComboBoxVaultAlias.SelectedItem = match;
+            if (this.SetCurrentVaultAlias())
+            {
+                this.uxMenuItemRefresh.PerformClick();
+            }
         }
 
         private void ApplySettings()
@@ -132,6 +162,11 @@ namespace Microsoft.Vault.Explorer
             UISettings.Default.MainFormSecretsSorting = this.uxListViewSecrets.Sorting;
             UISettings.Default.MainFormSecretsSortingColumn = this.uxListViewSecrets.SortingColumn;
             UISettings.Default.Save();
+            if (this.CurrentVaultAlias != null)
+            {
+                Settings.Default.LastUsedVaultAlias = this.CurrentVaultAlias.Alias;
+            }
+
             Settings.Default.Save();
         }
 
@@ -287,8 +322,19 @@ namespace Microsoft.Vault.Explorer
 
         private void RefreshItemsCount()
         {
-            this.uxStatusLabelSecertsCount.Text = string.IsNullOrWhiteSpace(this.uxTextBoxSearch.Text) ? $"{this.uxListViewSecrets.Items.Count} items" : $"{this.uxListViewSecrets.SearchResultsCount} out of {this.uxListViewSecrets.Items.Count} items";
+            int expiring = this.uxListViewSecrets.Items.Count > 0
+                ? this.uxListViewSecrets.Items.OfType<ListViewItemBase>().Count(i => !i.AboutToExpire)
+                : 0;
+
+            string vaultPrefix = this.CurrentVaultAlias != null ? $"{this.CurrentVaultAlias.Alias} — " : string.Empty;
+            string itemCount = string.IsNullOrWhiteSpace(this.uxTextBoxSearch.Text)
+                ? $"{this.uxListViewSecrets.Items.Count} items"
+                : $"{this.uxListViewSecrets.SearchResultsCount} out of {this.uxListViewSecrets.Items.Count} items";
+            string expiringLabel = expiring > 0 ? $" | {expiring} expiring" : string.Empty;
+
+            this.uxStatusLabelSecertsCount.Text = $"{vaultPrefix}{itemCount}{expiringLabel}";
             this.uxStatusLabelSecretsSelected.Text = $"{this.uxListViewSecrets.SelectedItems.Count} selected";
+            this.Text = expiring > 0 ? $"{this._titleBase} | {expiring} expiring" : this._titleBase;
         }
 
         private bool SetCurrentVaultAlias()
@@ -454,7 +500,8 @@ namespace Microsoft.Vault.Explorer
                     }
                     else // We were able to list from one or from both collections
                     {
-                        this.Text += $" ({this.CurrentVault.AuthenticatedUserName})";
+                        this._titleBase = $"{Globals.AppName} ({this.CurrentVault.AuthenticatedUserName})";
+                        this.Text = this._titleBase;
                         this.uxAddSecret.Visible = this.uxAddSecret2.Visible = this.uxAddCert.Visible = this.uxAddCert2.Visible = this.uxAddFile.Visible = this.uxAddFile2.Visible = this.CurrentVaultAlias.SecretsCollectionEnabled;
                         this.uxAddKVCert.Visible = this.uxAddKVCert2.Visible = this.CurrentVaultAlias.CertificatesCollectionEnabled;
                         this.uxListViewSecrets.AllowDrop = true;
@@ -836,6 +883,61 @@ namespace Microsoft.Vault.Explorer
                 {
                     this.uxListViewSecrets.ExportToTsv(this.uxSaveFileDialog.FileName);
                 }
+            }
+        }
+
+        private async void uxButtonCopyAsEnvVar_Click(object sender, EventArgs e)
+        {
+            var item = this.uxListViewSecrets.FirstSelectedItem;
+            if (null != item)
+            {
+                using (var op = this.NewUxOperationWithProgress(this.uxButtonCopyAsEnvVar, this.uxMenuItemCopyAsEnvVar))
+                {
+                    PropertyObject po = null;
+                    await op.Invoke($"get {item.Kind} from", async () => po = await item.GetAsync(op.CancellationToken));
+                    string envName = item.Name.Replace('-', '_').ToUpperInvariant();
+                    Clipboard.SetText($"{envName}={po.Value}");
+                }
+            }
+        }
+
+        private async void uxButtonCopyAsDockerEnv_Click(object sender, EventArgs e)
+        {
+            var item = this.uxListViewSecrets.FirstSelectedItem;
+            if (null != item)
+            {
+                using (var op = this.NewUxOperationWithProgress(this.uxButtonCopyAsDockerEnv, this.uxMenuItemCopyAsDockerEnv))
+                {
+                    PropertyObject po = null;
+                    await op.Invoke($"get {item.Kind} from", async () => po = await item.GetAsync(op.CancellationToken));
+                    string envName = item.Name.Replace('-', '_').ToUpperInvariant();
+                    Clipboard.SetText($"--env {envName}={po.Value}");
+                }
+            }
+        }
+
+        private async void uxButtonCopyAsK8sYaml_Click(object sender, EventArgs e)
+        {
+            var item = this.uxListViewSecrets.FirstSelectedItem;
+            if (null != item)
+            {
+                using (var op = this.NewUxOperationWithProgress(this.uxButtonCopyAsK8sYaml, this.uxMenuItemCopyAsK8sYaml))
+                {
+                    PropertyObject po = null;
+                    await op.Invoke($"get {item.Kind} from", async () => po = await item.GetAsync(op.CancellationToken));
+                    string envName = item.Name.Replace('-', '_').ToLowerInvariant();
+                    string yaml = $"apiVersion: v1\nkind: Secret\nmetadata:\n  name: {envName}\nstringData:\n  {item.Name}: {po.Value}";
+                    Clipboard.SetText(yaml);
+                }
+            }
+        }
+
+        private void uxButtonCopyName_Click(object sender, EventArgs e)
+        {
+            var item = this.uxListViewSecrets.FirstSelectedItem;
+            if (null != item)
+            {
+                Clipboard.SetText(item.Name);
             }
         }
 

--- a/Vault/Explorer/MainForm.cs
+++ b/Vault/Explorer/MainForm.cs
@@ -310,6 +310,17 @@ namespace Microsoft.Vault.Explorer
                             return false;
                         }
 
+                        if (smd.CurrentVaultAlias == null)
+                        {
+                            MessageBox.Show(
+                                "No vault was selected.\n\nChoose a subscription, select a vault, then click OK.",
+                                "Vault selection required",
+                                MessageBoxButtons.OK,
+                                MessageBoxIcon.Information);
+                            this.uxComboBoxVaultAlias.SelectedItem = this.CurrentVaultAlias;
+                            return false;
+                        }
+
                         // Add vault to temporary collection since it's new
                         this._tempVaultAliases[smd.CurrentVaultAlias.Alias] = smd.CurrentVaultAlias;
                         this.uxComboBoxVaultAlias.Items.Insert(this.uxComboBoxVaultAlias.Items.Count - 2, smd.CurrentVaultAlias);

--- a/Vault/Explorer/Model/Collections/LifetimeActionItem.cs
+++ b/Vault/Explorer/Model/Collections/LifetimeActionItem.cs
@@ -1,14 +1,14 @@
 namespace Microsoft.Vault.Explorer.Model.Collections
 {
     using System.ComponentModel;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Certificates;
 
     [DefaultProperty("Type")]
     [Description("Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.")]
     public class LifetimeActionItem
     {
         [Category("Action")]
-        public ActionType? Type { get; set; }
+        public CertificatePolicyAction? Type { get; set; }
 
         [Category("Trigger")]
         public int? DaysBeforeExpiry { get; set; }

--- a/Vault/Explorer/Model/Collections/LifetimeActionTypeEnumConverter.cs
+++ b/Vault/Explorer/Model/Collections/LifetimeActionTypeEnumConverter.cs
@@ -1,9 +1,9 @@
 namespace Microsoft.Vault.Explorer.Model.Collections
 {
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Certificates;
     using Microsoft.Vault.Explorer.Model.ContentTypes;
 
-    public class LifetimeActionTypeEnumConverter : CustomEnumTypeConverter<ActionType>
+    public class LifetimeActionTypeEnumConverter : CustomEnumTypeConverter<CertificatePolicyAction>
     {
     }
 }

--- a/Vault/Explorer/Model/Files/Secrets/CertificateFileData.cs
+++ b/Vault/Explorer/Model/Files/Secrets/CertificateFileData.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Vault.Explorer.Model.Files.Secrets
+{
+    using System;
+    using System.Collections.Generic;
+    using Azure.Security.KeyVault.Certificates;
+    using Microsoft.Vault.Library;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    ///     DTO used to persist a <see cref="KeyVaultCertificate"/> to a .kv-certificate file.
+    ///     Replaces the old CertificateBundle dependency.
+    /// </summary>
+    [JsonObject]
+    public class CertificateFileData
+    {
+        [JsonProperty]
+        public string Id { get; set; }
+
+        [JsonProperty]
+        public byte[] Cer { get; set; }
+
+        [JsonProperty]
+        public bool? Enabled { get; set; }
+
+        [JsonProperty]
+        public DateTimeOffset? ExpiresOn { get; set; }
+
+        [JsonProperty]
+        public DateTimeOffset? NotBefore { get; set; }
+
+        [JsonProperty]
+        public Dictionary<string, string> Tags { get; set; }
+
+        public static CertificateFileData FromCertificate(KeyVaultCertificate c)
+        {
+            var data = new CertificateFileData
+            {
+                Id = c.Id?.ToString(),
+                Cer = c.Cer,
+                Enabled = c.Properties.Enabled,
+                ExpiresOn = c.Properties.ExpiresOn,
+                NotBefore = c.Properties.NotBefore,
+            };
+            if (c.Properties.Tags.Count > 0)
+            {
+                data.Tags = new Dictionary<string, string>(c.Properties.Tags);
+            }
+
+            return data;
+        }
+
+        public ObjectIdentifier ToObjectIdentifier()
+        {
+            if (string.IsNullOrEmpty(this.Id))
+                return new ObjectIdentifier(null, null, null, null);
+            var uri = new Uri(this.Id);
+            var segments = uri.AbsolutePath.TrimStart('/').Split('/');
+            string name = segments.Length > 1 ? segments[1] : null;
+            string version = segments.Length > 2 ? segments[2] : string.Empty;
+            string vault = $"{uri.Scheme}://{uri.Host}";
+            return new ObjectIdentifier(name, this.Id, version, vault);
+        }
+    }
+}

--- a/Vault/Explorer/Model/Files/Secrets/KeyVaultCertificateFile.cs
+++ b/Vault/Explorer/Model/Files/Secrets/KeyVaultCertificateFile.cs
@@ -1,19 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 namespace Microsoft.Vault.Explorer.Model.Files.Secrets
 {
-    using Microsoft.Azure.KeyVault.Models;
     using Newtonsoft.Json;
 
     /// <summary>
     ///     Represents .kv-certificate file
     /// </summary>
     [JsonObject]
-    public class KeyVaultCertificateFile : KeyVaultFile<CertificateBundle>
+    public class KeyVaultCertificateFile : KeyVaultFile<CertificateFileData>
     {
         public KeyVaultCertificateFile()
         {
         }
 
-        public KeyVaultCertificateFile(CertificateBundle cb) : base(cb)
+        public KeyVaultCertificateFile(CertificateFileData data) : base(data)
         {
         }
     }

--- a/Vault/Explorer/Model/Files/Secrets/KeyVaultSecretFile.cs
+++ b/Vault/Explorer/Model/Files/Secrets/KeyVaultSecretFile.cs
@@ -3,20 +3,19 @@
 
 namespace Microsoft.Vault.Explorer.Model.Files.Secrets
 {
-    using Microsoft.Azure.KeyVault.Models;
     using Newtonsoft.Json;
 
     /// <summary>
     ///     Represents .kv-secret file
     /// </summary>
     [JsonObject]
-    public class KeyVaultSecretFile : KeyVaultFile<SecretBundle>
+    public class KeyVaultSecretFile : KeyVaultFile<SecretFileData>
     {
         public KeyVaultSecretFile()
         {
         }
 
-        public KeyVaultSecretFile(SecretBundle secret) : base(secret)
+        public KeyVaultSecretFile(SecretFileData data) : base(data)
         {
         }
     }

--- a/Vault/Explorer/Model/Files/Secrets/SecretFileData.cs
+++ b/Vault/Explorer/Model/Files/Secrets/SecretFileData.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Vault.Explorer.Model.Files.Secrets
+{
+    using System;
+    using System.Collections.Generic;
+    using Azure.Security.KeyVault.Secrets;
+    using Microsoft.Vault.Library;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    ///     DTO used to persist a <see cref="KeyVaultSecret"/> to a .kv-secret file.
+    ///     Replaces the old SecretBundle dependency.
+    /// </summary>
+    [JsonObject]
+    public class SecretFileData
+    {
+        [JsonProperty]
+        public string Id { get; set; }
+
+        [JsonProperty]
+        public string Value { get; set; }
+
+        [JsonProperty]
+        public string ContentType { get; set; }
+
+        [JsonProperty]
+        public bool? Enabled { get; set; }
+
+        [JsonProperty]
+        public DateTimeOffset? ExpiresOn { get; set; }
+
+        [JsonProperty]
+        public DateTimeOffset? NotBefore { get; set; }
+
+        [JsonProperty]
+        public Dictionary<string, string> Tags { get; set; }
+
+        public static SecretFileData FromSecret(KeyVaultSecret s)
+        {
+            var data = new SecretFileData
+            {
+                Id = s.Id?.ToString(),
+                Value = s.Value,
+                ContentType = s.Properties.ContentType,
+                Enabled = s.Properties.Enabled,
+                ExpiresOn = s.Properties.ExpiresOn,
+                NotBefore = s.Properties.NotBefore,
+            };
+            if (s.Properties.Tags.Count > 0)
+            {
+                data.Tags = new Dictionary<string, string>(s.Properties.Tags);
+            }
+
+            return data;
+        }
+
+        public static SecretFileData ForNew(string contentType) => new SecretFileData
+        {
+            ContentType = contentType,
+        };
+
+        public ObjectIdentifier ToObjectIdentifier()
+        {
+            if (string.IsNullOrEmpty(this.Id))
+                return new ObjectIdentifier(null, null, null, null);
+            var uri = new Uri(this.Id);
+            var segments = uri.AbsolutePath.TrimStart('/').Split('/');
+            // segments: ["secrets", "name", "version"] or ["secrets", "name"]
+            string name = segments.Length > 1 ? segments[1] : null;
+            string version = segments.Length > 2 ? segments[2] : string.Empty;
+            string vault = $"{uri.Scheme}://{uri.Host}";
+            return new ObjectIdentifier(name, this.Id, version, vault);
+        }
+    }
+}

--- a/Vault/Explorer/Model/PropObjects/CertificateValueObject.cs
+++ b/Vault/Explorer/Model/PropObjects/CertificateValueObject.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
             this.Data = data;
             this.Password = password;
             byte[] rawData = Convert.FromBase64String(data);
-            this.Certificate = null == password ? new X509Certificate2(rawData) : new X509Certificate2(rawData, password, X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable);
+            this.Certificate = string.IsNullOrEmpty(password)
+                ? X509CertificateLoader.LoadCertificate(rawData)
+                : X509CertificateLoader.LoadPkcs12(rawData, password, X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable, Pkcs12LoaderLimits.Defaults);
         }
 
         public CertificateValueObject(FileInfo file, string password) :

--- a/Vault/Explorer/Model/PropObjects/PropertyObject.cs
+++ b/Vault/Explorer/Model/PropObjects/PropertyObject.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
     using System.Drawing.Design;
     using System.IO;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault;
     using Microsoft.Vault.Explorer.Controls;
     using Microsoft.Vault.Explorer.Controls.MenuItems;
     using Microsoft.Vault.Explorer.Model.Collections;

--- a/Vault/Explorer/Model/PropObjects/PropertyObjectCertificate.cs
+++ b/Vault/Explorer/Model/PropObjects/PropertyObjectCertificate.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
     using System.Linq;
     using System.Security.Cryptography.X509Certificates;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Certificates;
     using Microsoft.Vault.Explorer.Controls.MenuItems;
     using Microsoft.Vault.Explorer.Dialogs.Passwords;
     using Microsoft.Vault.Explorer.Model.Collections;
     using Microsoft.Vault.Explorer.Model.ContentTypes;
     using Microsoft.Vault.Explorer.Model.Files.Secrets;
+    using Microsoft.Vault.Library;
 
     /// <summary>
     ///     Certificate object to edit via PropertyGrid
@@ -25,12 +25,14 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
     [DefaultProperty("Certificate")]
     public class PropertyObjectCertificate : PropertyObject
     {
-        public readonly CertificateBundle CertificateBundle;
+        /// <summary>The vault-stored certificate resource, or null for a brand-new certificate.</summary>
+        public readonly KeyVaultCertificate CertificateBundle;
+
         public readonly CertificatePolicy CertificatePolicy;
 
         [Category("General")]
         [DisplayName("Certificate")]
-        [Description("Displays a system dialog that contains the properties of an X.509 certificate and its associated certificate chain. One can also install the cetificate locally by clicking on Install Certificate button in the dialog.")]
+        [Description("Displays a system dialog that contains the properties of an X.509 certificate and its associated certificate chain.")]
         [Editor(typeof(CertificateUIEditor), typeof(UITypeEditor))]
         public X509Certificate2 Certificate { get; }
 
@@ -39,43 +41,61 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
         public string Thumbprint => this.Certificate.Thumbprint?.ToLowerInvariant();
 
         [Category("Identifiers")]
-        [DisplayName("Certificate")]
-        [TypeConverter(typeof(ExpandableObjectConverter))]
-        public CertificateIdentifier Id => this.CertificateBundle.CertificateIdentifier;
+        [DisplayName("Certificate Id")]
+        public string Id => this.CertificateBundle?.Id?.ToString();
 
         [Category("Identifiers")]
-        [DisplayName("Key")]
-        [TypeConverter(typeof(ExpandableObjectConverter))]
-        public KeyIdentifier KeyId => this.CertificateBundle.KeyIdentifier;
+        [DisplayName("Key Id")]
+        public string KeyId => this.CertificateBundle?.KeyId?.ToString();
 
         [Category("Identifiers")]
-        [DisplayName("Secret")]
-        [TypeConverter(typeof(ExpandableObjectConverter))]
-        public SecretIdentifier SecretId => this.CertificateBundle.SecretIdentifier;
+        [DisplayName("Secret Id")]
+        public string SecretId => this.CertificateBundle?.SecretId?.ToString();
 
         [Category("Policy")]
-        [DisplayName("Attributes")]
+        [DisplayName("Enabled")]
         [ReadOnly(true)]
-        [TypeConverter(typeof(ExpandableObjectConverter))]
-        public CertificateAttributes PolicyAttributes => this.CertificatePolicy.Attributes;
+        public bool? PolicyEnabled => this.CertificatePolicy?.Enabled;
 
         [Category("Policy")]
-        [DisplayName("Certificate properties")]
+        [DisplayName("Issuer")]
         [ReadOnly(true)]
-        [TypeConverter(typeof(ExpandableObjectConverter))]
-        public X509CertificateProperties X509CertificateProperties => this.CertificatePolicy.X509CertificateProperties;
+        public string Issuer => this.CertificatePolicy?.IssuerName;
 
         [Category("Policy")]
-        [DisplayName("Key properties")]
+        [DisplayName("Certificate Type")]
         [ReadOnly(true)]
-        [TypeConverter(typeof(ExpandableObjectConverter))]
-        public KeyProperties KeyProperties => this.CertificatePolicy.KeyProperties;
+        public string CertificateType => this.CertificatePolicy?.CertificateType;
 
         [Category("Policy")]
-        [DisplayName("Secret properties")]
+        [DisplayName("Key Type")]
         [ReadOnly(true)]
-        [TypeConverter(typeof(ExpandableObjectConverter))]
-        public SecretProperties SecretProperties => this.CertificatePolicy.SecretProperties;
+        public string KeyType => this.CertificatePolicy?.KeyType;
+
+        [Category("Policy")]
+        [DisplayName("Key Size")]
+        [ReadOnly(true)]
+        public int? KeySize => this.CertificatePolicy?.KeySize;
+
+        [Category("Policy")]
+        [DisplayName("Exportable")]
+        [ReadOnly(true)]
+        public bool? Exportable => this.CertificatePolicy?.Exportable;
+
+        [Category("Policy")]
+        [DisplayName("Reuse Key")]
+        [ReadOnly(true)]
+        public bool? ReuseKey => this.CertificatePolicy?.ReuseKey;
+
+        [Category("Policy")]
+        [DisplayName("Content Type")]
+        [ReadOnly(true)]
+        public string PolicyContentType => this.CertificatePolicy?.ContentType?.ToString();
+
+        [Category("Policy")]
+        [DisplayName("Subject")]
+        [ReadOnly(true)]
+        public string Subject => this.CertificatePolicy?.Subject;
 
         private ObservableLifetimeActionsCollection _lifetimeActions;
 
@@ -89,21 +109,35 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
             set
             {
                 this._lifetimeActions = value;
-                if (null != this.CertificatePolicy)
+                if (this.CertificatePolicy?.LifetimeActions != null)
                 {
-                    this.CertificatePolicy.LifetimeActions = this.LifetimeActionsToList();
+                    this.CertificatePolicy.LifetimeActions.Clear();
+                    foreach (var lai in value)
+                    {
+                        this.CertificatePolicy.LifetimeActions.Add(new LifetimeAction(lai.Type ?? CertificatePolicyAction.AutoRenew)
+                        {
+                            DaysBeforeExpiry = lai.DaysBeforeExpiry,
+                            LifetimePercentage = lai.LifetimePercentage,
+                        });
+                    }
                 }
             }
         }
 
-        [Category("Policy")]
-        [DisplayName("Issuer parameters")]
-        [ReadOnly(true)]
-        [TypeConverter(typeof(ExpandableObjectConverter))]
-        public IssuerParameters IssuerReference => this.CertificatePolicy.IssuerParameters;
-
-        public PropertyObjectCertificate(CertificateBundle certificateBundle, CertificatePolicy policy, X509Certificate2 certificate, PropertyChangedEventHandler propertyChanged) :
-            base(certificateBundle.CertificateIdentifier, certificateBundle.Tags, certificateBundle.Attributes.Enabled, certificateBundle.Attributes.Expires, certificateBundle.Attributes.NotBefore, propertyChanged)
+        public PropertyObjectCertificate(KeyVaultCertificate certificateBundle, CertificatePolicy policy, X509Certificate2 certificate, PropertyChangedEventHandler propertyChanged) :
+            base(
+                certificateBundle != null
+                    ? new ObjectIdentifier(
+                        certificateBundle.Name,
+                        certificateBundle.Id?.ToString() ?? string.Empty,
+                        certificateBundle.Properties.Version ?? string.Empty,
+                        certificateBundle.Properties.VaultUri?.ToString() ?? string.Empty)
+                    : new ObjectIdentifier(null, null, null, null),
+                certificateBundle?.Properties.Tags,
+                certificateBundle?.Properties.Enabled,
+                certificateBundle?.Properties.ExpiresOn?.UtcDateTime,
+                certificateBundle?.Properties.NotBefore?.UtcDateTime,
+                propertyChanged)
         {
             this.CertificateBundle = certificateBundle;
             this.CertificatePolicy = policy;
@@ -111,19 +145,22 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
             this._contentType = ContentType.Pkcs12;
             this._value = certificate.Thumbprint.ToLowerInvariant();
             var olac = new ObservableLifetimeActionsCollection();
-            if (null != this.CertificatePolicy?.LifetimeActions)
+            if (this.CertificatePolicy?.LifetimeActions != null)
             {
                 foreach (var la in this.CertificatePolicy.LifetimeActions)
                 {
-                    olac.Add(new LifetimeActionItem { Type = la.Action.ActionType, DaysBeforeExpiry = la.Trigger.DaysBeforeExpiry, LifetimePercentage = la.Trigger.LifetimePercentage });
+                    olac.Add(new LifetimeActionItem
+                    {
+                        Type = la.Action,
+                        DaysBeforeExpiry = la.DaysBeforeExpiry,
+                        LifetimePercentage = la.LifetimePercentage,
+                    });
                 }
             }
 
             this.LifetimeActions = olac;
             this.LifetimeActions.SetPropertyChangedEventHandler(propertyChanged);
         }
-
-        public CertificateAttributes ToCertificateAttributes() => new CertificateAttributes { Enabled = this.Enabled, Expires = this.Expires, NotBefore = this.NotBefore };
 
         public override string GetKeyVaultFileExtension() => ContentType.KeyVaultCertificate.ToExtension();
 
@@ -141,8 +178,11 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
             {
                 case ContentType.KeyVaultSecret:
                     throw new InvalidOperationException("One can't save key vault certificate as key vault secret");
-                case ContentType.KeyVaultCertificate: // Serialize the entire secret as encrypted JSON for current user
-                    File.WriteAllText(fullName, new KeyVaultCertificateFile(this.CertificateBundle).Serialize());
+                case ContentType.KeyVaultCertificate:
+                    if (this.CertificateBundle != null)
+                    {
+                        File.WriteAllText(fullName, new KeyVaultCertificateFile(CertificateFileData.FromCertificate(this.CertificateBundle)).Serialize());
+                    }
                     break;
                 case ContentType.KeyVaultLink:
                     File.WriteAllText(fullName, this.GetLinkAsInternetShortcut());
@@ -180,9 +220,6 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
         {
         }
 
-        public override string AreCustomTagsValid() => ""; // Return always valid
-
-        private IList<LifetimeAction> LifetimeActionsToList() =>
-            (from lai in this.LifetimeActions select new LifetimeAction(new Trigger(lai.LifetimePercentage, lai.DaysBeforeExpiry), new Azure.KeyVault.Models.Action(lai.Type))).ToList();
+        public override string AreCustomTagsValid() => "";
     }
 }

--- a/Vault/Explorer/Model/PropObjects/PropertyObjectSecret.cs
+++ b/Vault/Explorer/Model/PropObjects/PropertyObjectSecret.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Windows.Forms;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure.Security.KeyVault.Secrets;
     using Microsoft.Vault.Explorer.Controls.MenuItems;
     using Microsoft.Vault.Explorer.Model.Collections;
     using Microsoft.Vault.Explorer.Model.ContentTypes;
@@ -28,9 +28,9 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
     public class PropertyObjectSecret : PropertyObject
     {
         /// <summary>
-        ///     Original secret
+        ///     Original secret (null when creating a brand-new secret)
         /// </summary>
-        private readonly SecretBundle _secret;
+        private readonly KeyVaultSecret _secret;
 
         private readonly CustomTags _customTags;
 
@@ -55,13 +55,52 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
             get { return this._version; }
         }
 
-        public PropertyObjectSecret(SecretBundle secret, PropertyChangedEventHandler propertyChanged) :
-            base(secret.SecretIdentifier, secret.Tags, secret.Attributes.Enabled, secret.Attributes.Expires, secret.Attributes.NotBefore, propertyChanged)
+        /// <summary>Constructor for an existing secret fetched from vault.</summary>
+        public PropertyObjectSecret(KeyVaultSecret secret, PropertyChangedEventHandler propertyChanged) :
+            base(
+                new ObjectIdentifier(
+                    secret.Name,
+                    secret.Id?.ToString() ?? string.Empty,
+                    secret.Properties.Version ?? string.Empty,
+                    secret.Properties.VaultUri?.ToString() ?? string.Empty),
+                secret.Properties.Tags,
+                secret.Properties.Enabled,
+                secret.Properties.ExpiresOn?.UtcDateTime,
+                secret.Properties.NotBefore?.UtcDateTime,
+                propertyChanged)
         {
             this._secret = secret;
-            this._version = secret.SecretIdentifier?.Version;
-            this._contentType = ContentTypeEnumConverter.GetValue(secret.ContentType);
+            this._version = secret.Properties.Version;
+            this._contentType = ContentTypeEnumConverter.GetValue(secret.Properties.ContentType);
             this._value = this._contentType.FromRawValue(secret.Value);
+            this._customTags = Utils.LoadFromJsonFile<CustomTags>(Settings.Default.CustomTagsJsonFileLocation, isOptional: true);
+        }
+
+        /// <summary>Constructor for a secret loaded from a .kv-secret file.</summary>
+        public PropertyObjectSecret(SecretFileData fileData, PropertyChangedEventHandler propertyChanged) :
+            base(
+                fileData.ToObjectIdentifier(),
+                fileData.Tags,
+                fileData.Enabled,
+                fileData.ExpiresOn?.UtcDateTime,
+                fileData.NotBefore?.UtcDateTime,
+                propertyChanged)
+        {
+            this._secret = null;
+            this._version = fileData.ToObjectIdentifier().Version;
+            this._contentType = ContentTypeEnumConverter.GetValue(fileData.ContentType);
+            this._value = this._contentType.FromRawValue(fileData.Value);
+            this._customTags = Utils.LoadFromJsonFile<CustomTags>(Settings.Default.CustomTagsJsonFileLocation, isOptional: true);
+        }
+
+        /// <summary>Constructor for a brand-new secret (not yet in vault).</summary>
+        public PropertyObjectSecret(string contentType, PropertyChangedEventHandler propertyChanged) :
+            base(new ObjectIdentifier(null, null, null, null), null, null, null, null, propertyChanged)
+        {
+            this._secret = null;
+            this._version = null;
+            this._contentType = ContentTypeEnumConverter.GetValue(contentType);
+            this._value = null;
             this._customTags = Utils.LoadFromJsonFile<CustomTags>(Settings.Default.CustomTagsJsonFileLocation, isOptional: true);
         }
 
@@ -182,13 +221,6 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
             this.Expires = default(TimeSpan) == this.SecretKind.DefaultExpiration ? null : DateTime.UtcNow.Add(this.SecretKind.DefaultExpiration);
         }
 
-        public SecretAttributes ToSecretAttributes() => new SecretAttributes
-        {
-            Enabled = this.Enabled,
-            Expires = this.Expires,
-            NotBefore = this.NotBefore,
-        };
-
         public override string GetKeyVaultFileExtension() => ContentType.KeyVaultSecret.ToExtension();
 
         public override DataObject GetClipboardValue()
@@ -204,8 +236,11 @@ namespace Microsoft.Vault.Explorer.Model.PropObjects
             Directory.CreateDirectory(Path.GetDirectoryName(fullName));
             switch (ContentTypeUtils.FromExtension(Path.GetExtension(fullName)))
             {
-                case ContentType.KeyVaultSecret: // Serialize the entire secret as encrypted JSON for current user
-                    File.WriteAllText(fullName, new KeyVaultSecretFile(this._secret).Serialize());
+                case ContentType.KeyVaultSecret:
+                    if (this._secret != null)
+                    {
+                        File.WriteAllText(fullName, new KeyVaultSecretFile(SecretFileData.FromSecret(this._secret)).Serialize());
+                    }
                     break;
                 case ContentType.KeyVaultCertificate:
                     throw new InvalidOperationException("One can't save key vault secret as key vault certificate");

--- a/Vault/Explorer/Properties/PublishProfiles/ClickOnceProfile.pubxml
+++ b/Vault/Explorer/Properties/PublishProfiles/ClickOnceProfile.pubxml
@@ -5,16 +5,16 @@
     <BootstrapperEnabled>True</BootstrapperEnabled>
     <Configuration>Release</Configuration>
     <CreateWebPageOnPublish>True</CreateWebPageOnPublish>
-    <ErrorReportUrl>https://github.com/reysic/AzureKeyVaultExplorer/issues</ErrorReportUrl>
+    <ErrorReportUrl>https://github.com/alta01/AzureKeyVaultExplorer/issues</ErrorReportUrl>
     <GenerateManifests>true</GenerateManifests>
     <Install>True</Install>
     <InstallFrom>Web</InstallFrom>
-    <InstallUrl>https://reysic.github.io/AzureKeyVaultExplorer/</InstallUrl>
+    <InstallUrl>https://alta01.github.io/AzureKeyVaultExplorer/</InstallUrl>
     <IsRevisionIncremented>False</IsRevisionIncremented>
     <IsWebBootstrapper>True</IsWebBootstrapper>
     <MapFileExtensions>true</MapFileExtensions>
     <OpenBrowserOnPublish>False</OpenBrowserOnPublish>
-    <PublishDir>bin\Release\net8.0-windows10.0.17763.0\win-x64\app.publish\</PublishDir>
+    <PublishDir>bin\Release\net10.0-windows10.0.17763.0\win-x64\app.publish\</PublishDir>
     <PublishUrl>bin\publish\</PublishUrl>
     <PublishProtocol>ClickOnce</PublishProtocol>
     <PublishReadyToRun>False</PublishReadyToRun>
@@ -23,7 +23,7 @@
     <SignatureAlgorithm>(none)</SignatureAlgorithm>
     <SignManifests>False</SignManifests>
     <SkipPublishVerification>false</SkipPublishVerification>
-    <SupportUrl>https://github.com/reysic/AzureKeyVaultExplorer/issues</SupportUrl>
+    <SupportUrl>https://github.com/alta01/AzureKeyVaultExplorer/issues</SupportUrl>
     <TrustUrlParameters>True</TrustUrlParameters>
     <UpdateEnabled>True</UpdateEnabled>
     <UpdateMode>Foreground</UpdateMode>
@@ -34,6 +34,6 @@
     <ApplicationVersion>1.0.0.0</ApplicationVersion>
     <Platform>Any CPU</Platform>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/Vault/Explorer/Properties/PublishProfiles/ClickOnceProfile.pubxml
+++ b/Vault/Explorer/Properties/PublishProfiles/ClickOnceProfile.pubxml
@@ -5,11 +5,11 @@
     <BootstrapperEnabled>True</BootstrapperEnabled>
     <Configuration>Release</Configuration>
     <CreateWebPageOnPublish>True</CreateWebPageOnPublish>
-    <ErrorReportUrl>https://github.com/alta01/AzureKeyVaultExplorer/issues</ErrorReportUrl>
+    <ErrorReportUrl>https://github.com/reysic/AzureKeyVaultExplorer/issues</ErrorReportUrl>
     <GenerateManifests>true</GenerateManifests>
     <Install>True</Install>
     <InstallFrom>Web</InstallFrom>
-    <InstallUrl>https://alta01.github.io/AzureKeyVaultExplorer/</InstallUrl>
+    <InstallUrl>https://reysic.github.io/AzureKeyVaultExplorer/</InstallUrl>
     <IsRevisionIncremented>False</IsRevisionIncremented>
     <IsWebBootstrapper>True</IsWebBootstrapper>
     <MapFileExtensions>true</MapFileExtensions>
@@ -23,7 +23,7 @@
     <SignatureAlgorithm>(none)</SignatureAlgorithm>
     <SignManifests>False</SignManifests>
     <SkipPublishVerification>false</SkipPublishVerification>
-    <SupportUrl>https://github.com/alta01/AzureKeyVaultExplorer/issues</SupportUrl>
+    <SupportUrl>https://github.com/reysic/AzureKeyVaultExplorer/issues</SupportUrl>
     <TrustUrlParameters>True</TrustUrlParameters>
     <UpdateEnabled>True</UpdateEnabled>
     <UpdateMode>Foreground</UpdateMode>

--- a/Vault/Explorer/Settings.cs
+++ b/Vault/Explorer/Settings.cs
@@ -164,6 +164,15 @@ namespace Microsoft.Vault.Explorer
         }
 
         [UserScopedSetting]
+        [DefaultSettingValue("")]
+        [Browsable(false)]
+        public string LastUsedVaultAlias
+        {
+            get { return (string)this[nameof(this.LastUsedVaultAlias)]; }
+            set { this[nameof(this.LastUsedVaultAlias)] = value; }
+        }
+
+        [UserScopedSetting]
         [DefaultSettingValue("True")]
         [Browsable(false)]
         public bool UpgradeRequired

--- a/Vault/Explorer/VaultExplorer.csproj
+++ b/Vault/Explorer/VaultExplorer.csproj
@@ -29,8 +29,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="fernandreu.ScintillaNET" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Azure.Management.KeyVault" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.2.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.77.1" />
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.77.1" />
   </ItemGroup>

--- a/Vault/Explorer/VaultExplorer.csproj
+++ b/Vault/Explorer/VaultExplorer.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Build\AutoVersioning.props" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <OutputType>WinExe</OutputType>
     <RootNamespace>Microsoft.Vault.Explorer</RootNamespace>
@@ -17,7 +17,8 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <NoWarn>;NU1507</NoWarn>
-    <GenerateManifests>true</GenerateManifests>
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
+    <GenerateManifests>false</GenerateManifests>
     <TargetZone>LocalIntranet</TargetZone>
     <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
     <SignAssembly>True</SignAssembly>
@@ -29,9 +30,9 @@
   <ItemGroup>
     <PackageReference Include="fernandreu.ScintillaNET" Version="4.2.0" />
     <PackageReference Include="Microsoft.Azure.Management.KeyVault" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.77.1" />
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.77.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Controls\Lists\ListViewSecrets.cs">

--- a/Vault/Library/KeyVaultClientEx.cs
+++ b/Vault/Library/KeyVaultClientEx.cs
@@ -3,28 +3,40 @@
 
 namespace Microsoft.Vault.Library
 {
-    using Microsoft.Azure.KeyVault;
+    using System;
+    using Azure.Core;
+    using Azure.Security.KeyVault.Certificates;
+    using Azure.Security.KeyVault.Secrets;
 
     /// <summary>
-    ///     Simple wrapper around KeyVaultClient
+    ///     Holds <see cref="SecretClient"/> and <see cref="CertificateClient"/> for a single vault,
+    ///     replacing the old KeyVaultClientEx which extended the deprecated KeyVaultClient.
     /// </summary>
-    internal class KeyVaultClientEx : KeyVaultClient
+    internal sealed class VaultKeyValueClient
     {
         public readonly string VaultName;
         public readonly string VaultUri;
+        public readonly SecretClient SecretClient;
+        public readonly CertificateClient CertificateClient;
 
-        public KeyVaultClientEx(string vaultName, AuthenticationCallback authenticationCallback) : base(authenticationCallback)
+        internal VaultKeyValueClient(string vaultName, TokenCredential credential)
         {
             Utils.GuardVaultName(vaultName);
             this.VaultName = vaultName;
-            this.VaultUri = string.Format(Consts.AzureVaultUriFormat, this.VaultName);
+            this.VaultUri = string.Format(Consts.AzureVaultUriFormat, vaultName);
+            var vaultUri = new Uri(this.VaultUri);
+            this.SecretClient = new SecretClient(vaultUri, credential);
+            this.CertificateClient = new CertificateClient(vaultUri, credential);
         }
 
-        private string ToIdentifier(string endpoint, string name, string version) => $"{this.VaultUri}/{endpoint}/{name}" + (string.IsNullOrEmpty(version) ? "" : $"/{version}");
+        private string ToIdentifier(string endpoint, string name, string version) =>
+            $"{this.VaultUri}/{endpoint}/{name}" + (string.IsNullOrEmpty(version) ? "" : $"/{version}");
 
-        public string ToSecretIdentifier(string secretName, string version = null) => this.ToIdentifier(Consts.SecretsEndpoint, secretName, version);
+        public string ToSecretIdentifier(string secretName, string version = null) =>
+            this.ToIdentifier(Consts.SecretsEndpoint, secretName, version);
 
-        public string ToCertificateIdentifier(string certificateName, string version = null) => this.ToIdentifier(Consts.CertificatesEndpoint, certificateName, version);
+        public string ToCertificateIdentifier(string certificateName, string version = null) =>
+            this.ToIdentifier(Consts.CertificatesEndpoint, certificateName, version);
 
         public override string ToString() => this.VaultUri;
     }

--- a/Vault/Library/ObjectIdentifier.cs
+++ b/Vault/Library/ObjectIdentifier.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Vault.Library
+{
+    /// <summary>
+    /// Local replacement for the deprecated Microsoft.Azure.KeyVault.ObjectIdentifier.
+    /// Provides the same Name/Identifier/Version/Vault surface used throughout the UI layer.
+    /// </summary>
+    public sealed class ObjectIdentifier
+    {
+        /// <summary>The object name (e.g. "my-secret").</summary>
+        public string Name { get; }
+
+        /// <summary>The full versioned URI (e.g. "https://vault.azure.net/secrets/name/version").</summary>
+        public string Identifier { get; }
+
+        /// <summary>The version string, or empty string for the latest version.</summary>
+        public string Version { get; }
+
+        /// <summary>The base vault URI (e.g. "https://vault.azure.net").</summary>
+        public string Vault { get; }
+
+        public ObjectIdentifier(string name, string identifier, string version, string vault)
+        {
+            this.Name = name ?? string.Empty;
+            this.Identifier = identifier ?? string.Empty;
+            this.Version = version ?? string.Empty;
+            this.Vault = vault ?? string.Empty;
+        }
+    }
+}

--- a/Vault/Library/Vault.cs
+++ b/Vault/Library/Vault.cs
@@ -457,7 +457,7 @@ namespace Microsoft.Vault.Library
         public async Task<X509Certificate2> GetCertificateWithExportableKeysAsync(string certificateName, string certificateVersion = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             SecretBundle s = await this.GetSecretAsync(certificateName, certificateVersion, cancellationToken);
-            var cert = new X509Certificate2(Convert.FromBase64String(s.Value), string.Empty, X509KeyStorageFlags.Exportable);
+            var cert = X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(s.Value), string.Empty, X509KeyStorageFlags.Exportable, Pkcs12LoaderLimits.Defaults);
             return cert;
         }
 

--- a/Vault/Library/Vault.cs
+++ b/Vault/Library/Vault.cs
@@ -11,8 +11,9 @@ namespace Microsoft.Vault.Library
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.KeyVault;
-    using Microsoft.Azure.KeyVault.Models;
+    using Azure;
+    using Azure.Security.KeyVault.Certificates;
+    using Azure.Security.KeyVault.Secrets;
     using Microsoft.Vault.Core;
     using Newtonsoft.Json;
 
@@ -30,21 +31,20 @@ namespace Microsoft.Vault.Library
     /// </remarks>
     public class Vault
     {
-        private readonly KeyVaultClientEx[] _keyVaultClients;
+        private readonly VaultKeyValueClient[] _keyVaultClients;
         private bool Secondary => this._keyVaultClients.Length == 2;
 
         public readonly string VaultsConfigFile;
         public readonly string[] VaultNames;
         public readonly VaultsConfig VaultsConfig;
 
-        private static readonly Task CompletedTask = Task.FromResult(0); // Dummy completed task to be used for secondary operations, in case we work with only Primary vault
+        private static readonly Task CompletedTask = Task.FromResult(0);
         private static readonly object Lock = new object();
 
         /// <summary>
         ///     UserPrincipalName, in UPN format of the currently authenticated user, in case of cert based access the value will
         ///     be: {Environment.UserDomainName}\{Environment.UserName}
-        ///     The value will be set only after successful opertaion to vault, like:
-        ///     <see cref="ListSecretsAsync(int, ListOperationProgressUpdate, CancellationToken)" />
+        ///     The value will be set only after successful operation to vault.
         /// </summary>
         public string AuthenticatedUserName { get; private set; }
 
@@ -59,9 +59,6 @@ namespace Microsoft.Vault.Library
         /// <summary>
         ///     Creates the vault management instance based on provided Vaults Config dictionary
         /// </summary>
-        /// <param name="vaultsConfig">Vaults Config dictionary</param>
-        /// <param name="accessType">ReadOnly or ReadWrite</param>
-        /// <param name="vaultNames">Single or Dual</param>
         public Vault(VaultsConfig vaultsConfig, VaultAccessTypeEnum accessType, params string[] vaultNames)
         {
             Guard.ArgumentNotNull(vaultsConfig, nameof(vaultsConfig));
@@ -71,9 +68,9 @@ namespace Microsoft.Vault.Library
             switch (this.VaultNames.Length)
             {
                 case 1:
-                    this._keyVaultClients = new []
+                    this._keyVaultClients = new[]
                     {
-                        this.CreateKeyVaultClientEx(accessType, this.VaultNames[0]),
+                        this.CreateVaultKeyValueClient(accessType, this.VaultNames[0]),
                     };
                     break;
                 case 2:
@@ -84,9 +81,10 @@ namespace Microsoft.Vault.Library
                         throw new ArgumentException($"Primary vault name {primaryVaultName} is equal to secondary vault name {secondaryVaultName}");
                     }
 
-                    this._keyVaultClients = new KeyVaultClientEx[2]
+                    this._keyVaultClients = new VaultKeyValueClient[2]
                     {
-                        this.CreateKeyVaultClientEx(accessType, primaryVaultName), this.CreateKeyVaultClientEx(accessType, secondaryVaultName),
+                        this.CreateVaultKeyValueClient(accessType, primaryVaultName),
+                        this.CreateVaultKeyValueClient(accessType, secondaryVaultName),
                     };
                     break;
                 default:
@@ -97,14 +95,6 @@ namespace Microsoft.Vault.Library
         /// <summary>
         ///     Load specified Vaults.json configuration file and creates the vault management instance
         /// </summary>
-        /// <param name="vaultsConfigFile">
-        ///     Optional path to Vaults.json file, if NULL or empty default Vaults.json will be used, in such case Vaults.json
-        ///     location will be resolved in the following order:
-        ///     1. Side-by-side with the current process location
-        ///     2. Side-by-side with the current (executing) assembly
-        /// </param>
-        /// <param name="accessType">ReadOnly or ReadWrite</param>
-        /// <param name="vaultNames">Single or Dual</param>
         public Vault(string vaultsConfigFile, VaultAccessTypeEnum accessType, params string[] vaultNames)
             : this(DeserializeVaultsConfigFromFile(ref vaultsConfigFile), accessType, vaultNames)
         {
@@ -114,8 +104,6 @@ namespace Microsoft.Vault.Library
         /// <summary>
         ///     Single (primary) vault management constructor
         /// </summary>
-        /// <param name="accessType">ReadOnly or ReadWrite</param>
-        /// <param name="vaultNames">Single or pair</param>
         public Vault(VaultAccessTypeEnum accessType, params string[] vaultNames)
             : this(string.Empty, accessType, vaultNames)
         {
@@ -124,8 +112,6 @@ namespace Microsoft.Vault.Library
         /// <summary>
         ///     Single (primary) or Dual (primary and secondary) vault management constructor
         /// </summary>
-        /// <param name="accessType">ReadOnly or ReadWrite</param>
-        /// <param name="vaultName">Vault name</param>
         public Vault(VaultAccessTypeEnum accessType, string vaultName)
             : this(accessType, new[] { vaultName })
         {
@@ -134,9 +120,6 @@ namespace Microsoft.Vault.Library
         /// <summary>
         ///     Dual (primary and secondary) vault management constructor
         /// </summary>
-        /// <param name="accessType">ReadOnly or ReadWrite</param>
-        /// <param name="primaryVaultName">Primary vault name</param>
-        /// <param name="secondaryVaultName">Secodnary vault name</param>
         public Vault(VaultAccessTypeEnum accessType, string primaryVaultName, string secondaryVaultName)
             : this(accessType, new[] { primaryVaultName, secondaryVaultName })
         {
@@ -148,11 +131,8 @@ namespace Microsoft.Vault.Library
             {
                 TypeNameHandling = TypeNameHandling.Auto,
             };
-            if (string.IsNullOrWhiteSpace(vaultsConfigFile)) // Config file was not provied, use the default one
+            if (string.IsNullOrWhiteSpace(vaultsConfigFile))
             {
-                // Vaults.json location will be resolved in the following order:
-                // 1. Side-by-side with the current process location
-                // 2. Side-by-side with the current (executing) assembly
                 vaultsConfigFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Consts.VaultsJsonConfig);
                 if (!File.Exists(vaultsConfigFile))
                 {
@@ -163,87 +143,54 @@ namespace Microsoft.Vault.Library
             return JsonConvert.DeserializeObject<VaultsConfig>(File.ReadAllText(vaultsConfigFile), settings);
         }
 
-        private KeyVaultClientEx CreateKeyVaultClientEx(VaultAccessTypeEnum accessType, string vaultName) =>
-            new KeyVaultClientEx(vaultName, async (authority, resource, scope) =>
+        private VaultKeyValueClient CreateVaultKeyValueClient(VaultAccessTypeEnum accessType, string vaultName)
+        {
+            VaultAccess[] vas;
+            string userAliasType;
+
+            lock (Lock)
             {
-                // Prepare data outside the lock
-                VaultAccess[] vas;
-                string userAliasType;
-
-                lock (Lock)
+                Utils.GuardVaultName(vaultName);
+                if (false == this.VaultsConfig.ContainsKey(vaultName))
                 {
-                    Utils.GuardVaultName(vaultName);
-                    if (false == this.VaultsConfig.ContainsKey(vaultName))
-                    {
-                        throw new KeyNotFoundException($"{vaultName} is not found in {this.VaultsConfigFile}");
-                    }
-
-                    VaultAccessType vat = this.VaultsConfig[vaultName];
-                    vas = accessType == VaultAccessTypeEnum.ReadOnly ? vat.ReadOnly : vat.ReadWrite;
-
-                    // Order possible VaultAccess options by Order property
-                    vas = vas.OrderBy(va => va.Order).ToArray();
-
-                    // Get user alias for interactive authentication
-                    userAliasType = (from va in vas where va is VaultAccessUserInteractive select (VaultAccessUserInteractive)va).FirstOrDefault()?.UserAliasType;
+                    throw new KeyNotFoundException($"{vaultName} is not found in {this.VaultsConfigFile}");
                 }
 
-                // Convert resource URL to MSAL scopes
-                string[] scopes = VaultAccess.ConvertResourceToScopes(resource);
+                VaultAccessType vat = this.VaultsConfig[vaultName];
+                vas = accessType == VaultAccessTypeEnum.ReadOnly ? vat.ReadOnly : vat.ReadWrite;
+                vas = vas.OrderBy(va => va.Order).ToArray();
+                userAliasType = (from va in vas where va is VaultAccessUserInteractive select (VaultAccessUserInteractive)va).FirstOrDefault()?.UserAliasType;
+            }
 
-                Queue<Exception> exceptions = new Queue<Exception>();
-                string vaultAccessTypes = "";
-                foreach (VaultAccess va in vas)
-                {
-                    try
-                    {
-                        // If user alias type is different from environment, force login prompt, otherwise silently login
-                        var authResult = await va.AcquireTokenAsync(scopes, userAliasType);
-
-                        if (authResult.Account == null)
-                        {
-                            // should never happen
-                            throw new VaultAccessException("The authentication result doesn't include account information");
-                        }
-
-                        this.AuthenticatedUserName = authResult.Account.Username ?? userAliasType;
-
-                        return authResult.AccessToken;
-                    }
-                    catch (Exception e)
-                    {
-                        vaultAccessTypes += $" {va}";
-                        exceptions.Enqueue(e);
-                    }
-                }
-
-                throw new VaultAccessException($"Failed to get access to {vaultName} with all possible vault access type(s){vaultAccessTypes}", exceptions.ToArray());
+            var credential = new VaultAccessTokenCredential(vas, userAliasType, vaultName, username =>
+            {
+                this.AuthenticatedUserName = username;
             });
+
+            return new VaultKeyValueClient(vaultName, credential);
+        }
 
         #endregion
 
         #region Secrets
 
         /// <summary>
-        ///     Gets specified secret by name from vault
-        ///     This function will prefer vault in the same region, in case we failed (including secret not found) it will fallback
-        ///     to other region
-        ///     In case we failed in both regions it will throw aggregated SecretException
+        ///     Gets specified secret by name from vault.
+        ///     Prefers vault in same region; falls back to other region on failure.
         /// </summary>
-        /// <param name="secretName">The name the secret in the given vault</param>
-        /// <param name="secretVersion">The version of the secret (optional)</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>SecretBundle</returns>
-        public async Task<SecretBundle> GetSecretAsync(string secretName, string secretVersion = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<KeyVaultSecret> GetSecretAsync(string secretName, string secretVersion = null, CancellationToken cancellationToken = default)
         {
             Queue<Exception> exceptions = new Queue<Exception>();
             string vaults = "";
-            secretVersion = secretVersion ?? string.Empty;
             foreach (var kv in this._keyVaultClients)
             {
                 try
                 {
-                    return await kv.GetSecretAsync(kv.VaultUri, secretName, secretVersion, cancellationToken).ConfigureAwait(false);
+                    var response = await kv.SecretClient.GetSecretAsync(
+                        secretName,
+                        string.IsNullOrEmpty(secretVersion) ? null : secretVersion,
+                        cancellationToken).ConfigureAwait(false);
+                    return response.Value;
                 }
                 catch (Exception e)
                 {
@@ -258,21 +205,21 @@ namespace Microsoft.Vault.Library
         /// <summary>
         ///     Sets a secret in both vaults
         /// </summary>
-        /// <param name="secretName">The name the secret in the given vault</param>
-        /// <param name="value">The value of the secret</param>
-        /// <param name="tags">Application-specific metadata in the form of key-value pairs</param>
-        /// <param name="contentType">Type of the secret value such as a password</param>
-        /// <param name="secretAttributes">
-        ///     Attributes for the secret. For more information on possible attributes,
-        ///     <see cref="SecretAttributes" />
-        /// </param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>A response message containing the updated secret from first vault</returns>
-        public async Task<SecretBundle> SetSecretAsync(string secretName, string value, Dictionary<string, string> tags = null, string contentType = null, SecretAttributes secretAttributes = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<KeyVaultSecret> SetSecretAsync(string secretName, string value, Dictionary<string, string> tags = null, string contentType = null, bool? enabled = null, DateTimeOffset? expires = null, DateTimeOffset? notBefore = null, CancellationToken cancellationToken = default)
         {
             tags = Utils.AddMd5ChangedBy(tags, value, this.AuthenticatedUserName);
-            var t0 = this._keyVaultClients[0].SetSecretAsync(this._keyVaultClients[0].VaultUri, secretName, value, tags, contentType, secretAttributes, cancellationToken);
-            var t1 = this.Secondary ? this._keyVaultClients[1].SetSecretAsync(this._keyVaultClients[1].VaultUri, secretName, value, tags, contentType, secretAttributes, cancellationToken) : CompletedTask;
+            var secret = new KeyVaultSecret(secretName, value);
+            secret.Properties.ContentType = contentType;
+            secret.Properties.Enabled = enabled;
+            secret.Properties.ExpiresOn = expires;
+            secret.Properties.NotBefore = notBefore;
+            if (tags != null)
+            {
+                foreach (var kvp in tags) secret.Properties.Tags[kvp.Key] = kvp.Value;
+            }
+
+            var t0 = this._keyVaultClients[0].SecretClient.SetSecretAsync(secret, cancellationToken);
+            var t1 = this.Secondary ? this._keyVaultClients[1].SecretClient.SetSecretAsync(secret, cancellationToken) : Task.FromResult<Response<KeyVaultSecret>>(null);
             await Task.WhenAll(t0, t1).ContinueWith(t =>
             {
                 if (t0.IsFaulted && t1.IsFaulted)
@@ -290,28 +237,32 @@ namespace Microsoft.Vault.Library
                     throw new SecretException($"Failed to set secret {secretName} in vault {this._keyVaultClients[1]}", t1.Exception);
                 }
             });
-            return t0.Result;
+            return t0.Result.Value;
         }
 
         /// <summary>
-        ///     Updates the attributes associated with the specified secret in both vaults
+        ///     Updates the attributes associated with the specified secret in both vaults.
+        ///     Fetches the current version first so UpdateSecretPropertiesAsync gets a versioned URI.
         /// </summary>
-        /// <param name="secretName">The name of the secret in the given vault</param>
-        /// <param name="secretVersion">The secret version (optional)</param>
-        /// <param name="tags">Application-specific metadata in the form of key-value pairs</param>
-        /// <param name="contentType">Type of the secret value such as a password</param>
-        /// <param name="secretAttributes">
-        ///     Attributes for the secret. For more information on possible attributes,
-        ///     <see cref="SecretAttributes" />
-        /// </param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>A response message containing the updated secret from first vault</returns>
-        public async Task<SecretBundle> UpdateSecretAsync(string secretName, string secretVersion = null, Dictionary<string, string> tags = null, string contentType = null, SecretAttributes secretAttributes = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<SecretProperties> UpdateSecretAsync(string secretName, string secretVersion = null, Dictionary<string, string> tags = null, string contentType = null, bool? enabled = null, DateTimeOffset? expires = null, DateTimeOffset? notBefore = null, CancellationToken cancellationToken = default)
         {
             tags = Utils.AddMd5ChangedBy(tags, null, this.AuthenticatedUserName);
-            secretVersion = secretVersion ?? string.Empty;
-            var t0 = this._keyVaultClients[0].UpdateSecretAsync(this._keyVaultClients[0].VaultUri, secretName, secretVersion, contentType, secretAttributes, tags, cancellationToken);
-            var t1 = this.Secondary ? this._keyVaultClients[1].UpdateSecretAsync(this._keyVaultClients[1].VaultUri, secretName, secretVersion, contentType, secretAttributes, tags, cancellationToken) : CompletedTask;
+            string version = string.IsNullOrEmpty(secretVersion) ? null : secretVersion;
+
+            var current0 = await this._keyVaultClients[0].SecretClient.GetSecretAsync(secretName, version, cancellationToken).ConfigureAwait(false);
+            var props0 = current0.Value.Properties;
+            ApplyToSecretProperties(props0, tags, contentType, enabled, expires, notBefore);
+            var t0 = this._keyVaultClients[0].SecretClient.UpdateSecretPropertiesAsync(props0, cancellationToken);
+
+            Task<Response<SecretProperties>> t1 = Task.FromResult<Response<SecretProperties>>(null);
+            if (this.Secondary)
+            {
+                var current1 = await this._keyVaultClients[1].SecretClient.GetSecretAsync(secretName, version, cancellationToken).ConfigureAwait(false);
+                var props1 = current1.Value.Properties;
+                ApplyToSecretProperties(props1, tags, contentType, enabled, expires, notBefore);
+                t1 = this._keyVaultClients[1].SecretClient.UpdateSecretPropertiesAsync(props1, cancellationToken);
+            }
+
             await Task.WhenAll(t0, t1).ContinueWith(t =>
             {
                 if (t0.IsFaulted && t1.IsFaulted)
@@ -329,83 +280,52 @@ namespace Microsoft.Vault.Library
                     throw new SecretException($"Failed to update secret {secretName} in vault {this._keyVaultClients[1]}", t1.Exception);
                 }
             });
-            return t0.Result;
+            return t0.Result.Value;
+        }
+
+        private static void ApplyToSecretProperties(SecretProperties props, Dictionary<string, string> tags, string contentType, bool? enabled, DateTimeOffset? expires, DateTimeOffset? notBefore)
+        {
+            props.ContentType = contentType;
+            props.Enabled = enabled;
+            props.ExpiresOn = expires;
+            props.NotBefore = notBefore;
+            props.Tags.Clear();
+            if (tags != null)
+            {
+                foreach (var kvp in tags) props.Tags[kvp.Key] = kvp.Value;
+            }
         }
 
         /// <summary>
         ///     List all secrets from specified vault
-        ///     This function will only look in single specified Azure Key Vault. It will not fallback to other region.
         /// </summary>
-        /// <param name="regionIndex">0 - current region, 1 - other region</param>
-        /// <param name="listSecretsProgressUpdate">Optional progress update delegate</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>IEnumerable of SecretItem</returns>
-        public async Task<IEnumerable<SecretItem>> ListSecretsAsync(int regionIndex = 0, ListOperationProgressUpdate listSecretsProgressUpdate = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IEnumerable<SecretProperties>> ListSecretsAsync(int regionIndex = 0, ListOperationProgressUpdate listSecretsProgressUpdate = null, CancellationToken cancellationToken = default)
         {
             Guard.ArgumentIsValidRegion(regionIndex, nameof(regionIndex));
             Guard.ArgumentInRange(regionIndex, 0, this._keyVaultClients.Length - 1, nameof(regionIndex));
-            var listResponse = await this._keyVaultClients[regionIndex].GetSecretsAsync(this._keyVaultClients[regionIndex].VaultUri, Consts.ListSecretsMaxResults, cancellationToken: cancellationToken).ConfigureAwait(false);
-            Dictionary<string, SecretItem> result = new Dictionary<string, SecretItem>(StringComparer.InvariantCulture);
-            if (listResponse == null) // No secrets in the vault
+            var result = new Dictionary<string, SecretProperties>(StringComparer.InvariantCulture);
+            await foreach (var sp in this._keyVaultClients[regionIndex].SecretClient.GetPropertiesOfSecretsAsync(cancellationToken).ConfigureAwait(false))
             {
-                return result.Values;
-            }
-
-            foreach (SecretItem si in listResponse)
-            {
-                result[si.Identifier.Name] = si;
-            }
-
-            listSecretsProgressUpdate?.Invoke(result.Count);
-
-            while (!string.IsNullOrEmpty(listResponse.NextPageLink))
-            {
-                listResponse = await this._keyVaultClients[regionIndex].GetSecretsNextAsync(listResponse.NextPageLink, cancellationToken).ConfigureAwait(false);
-                foreach (SecretItem si in listResponse)
-                {
-                    result[si.Identifier.Name] = si;
-                }
-
+                result[sp.Name] = sp;
                 listSecretsProgressUpdate?.Invoke(result.Count);
             }
 
             return result.Values;
         }
 
-
         /// <summary>
         ///     List all the versions of a specified secret
-        ///     This function will only look in single specified Azure Key Vault. It will not fallback to other region.
         /// </summary>
-        /// <param name="secretName">The name of the secret in the given vault</param>
-        /// <param name="regionIndex">0 - current region, 1 - other region</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns></returns>
-        public async Task<IEnumerable<SecretItem>> GetSecretVersionsAsync(string secretName, int regionIndex = 0, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IEnumerable<SecretProperties>> GetSecretVersionsAsync(string secretName, int regionIndex = 0, CancellationToken cancellationToken = default)
         {
             Guard.ArgumentNotNullOrWhitespace(secretName, nameof(secretName));
             Guard.ArgumentIsValidRegion(regionIndex, nameof(regionIndex));
             Guard.ArgumentInRange(regionIndex, 0, this._keyVaultClients.Length - 1, nameof(regionIndex));
 
-            var listResponse = await this._keyVaultClients[regionIndex].GetSecretVersionsAsync(this._keyVaultClients[regionIndex].VaultUri, secretName, Consts.GetSecretVersionsMaxResults, cancellationToken: cancellationToken).ConfigureAwait(false);
-            Dictionary<string, SecretItem> result = new Dictionary<string, SecretItem>(StringComparer.InvariantCulture);
-            if (listResponse == null) // No secrets in the vault
+            var result = new Dictionary<string, SecretProperties>(StringComparer.InvariantCulture);
+            await foreach (var sp in this._keyVaultClients[regionIndex].SecretClient.GetPropertiesOfSecretVersionsAsync(secretName, cancellationToken).ConfigureAwait(false))
             {
-                return result.Values;
-            }
-
-            foreach (SecretItem si in listResponse)
-            {
-                result[si.Identifier.Identifier] = si;
-            }
-
-            while (!string.IsNullOrEmpty(listResponse.NextPageLink))
-            {
-                listResponse = await this._keyVaultClients[regionIndex].GetSecretVersionsNextAsync(listResponse.NextPageLink, cancellationToken).ConfigureAwait(false);
-                foreach (SecretItem si in listResponse)
-                {
-                    result[si.Identifier.Identifier] = si;
-                }
+                result[sp.Id.ToString()] = sp;
             }
 
             return result.Values;
@@ -414,13 +334,10 @@ namespace Microsoft.Vault.Library
         /// <summary>
         ///     Deletes a secret from both vaults
         /// </summary>
-        /// <param name="secretName">The name of the secret in the given vault</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>The deleted secret</returns>
-        public async Task<SecretBundle> DeleteSecretAsync(string secretName, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task DeleteSecretAsync(string secretName, CancellationToken cancellationToken = default)
         {
-            var t0 = this._keyVaultClients[0].DeleteSecretAsync(this._keyVaultClients[0].VaultUri, secretName, cancellationToken);
-            var t1 = this.Secondary ? this._keyVaultClients[1].DeleteSecretAsync(this._keyVaultClients[1].VaultUri, secretName, cancellationToken) : CompletedTask;
+            var t0 = this._keyVaultClients[0].SecretClient.StartDeleteSecretAsync(secretName, cancellationToken);
+            var t1 = this.Secondary ? this._keyVaultClients[1].SecretClient.StartDeleteSecretAsync(secretName, cancellationToken) : Task.FromResult<DeleteSecretOperation>(null);
             await Task.WhenAll(t0, t1).ContinueWith(t =>
             {
                 if (t0.IsFaulted && t1.IsFaulted)
@@ -438,8 +355,6 @@ namespace Microsoft.Vault.Library
                     throw new SecretException($"Failed to delete secret {secretName} from vault {this._keyVaultClients[1]}", t1.Exception);
                 }
             });
-
-            return t0.Result;
         }
 
         #endregion
@@ -447,37 +362,31 @@ namespace Microsoft.Vault.Library
         #region Certificates
 
         /// <summary>
-        ///     Gets a certificate with private and public keys. Keys are exportable.
-        ///     Returns a certificate with non-exportable keys
+        ///     Gets a certificate with exportable private key by fetching its secret representation.
         /// </summary>
-        /// <param name="certificateName">The name of the certificate in the given vault</param>
-        /// <param name="certificateVersion">The version of the certificate (optional)</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>A response message containing the certificate with private key.</returns>
-        public async Task<X509Certificate2> GetCertificateWithExportableKeysAsync(string certificateName, string certificateVersion = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<X509Certificate2> GetCertificateWithExportableKeysAsync(string certificateName, string certificateVersion = null, CancellationToken cancellationToken = default)
         {
-            SecretBundle s = await this.GetSecretAsync(certificateName, certificateVersion, cancellationToken);
-            var cert = X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(s.Value), string.Empty, X509KeyStorageFlags.Exportable, Pkcs12LoaderLimits.Defaults);
-            return cert;
+            KeyVaultSecret s = await this.GetSecretAsync(certificateName, certificateVersion, cancellationToken);
+            return X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(s.Value), string.Empty, X509KeyStorageFlags.Exportable, Pkcs12LoaderLimits.Defaults);
         }
 
         /// <summary>
-        ///     Gets a certificate.
+        ///     Gets a certificate. Falls back to secondary on failure.
         /// </summary>
-        /// <param name="certificateName">The name of the certificate in the given vault</param>
-        /// <param name="certificateVersion">The version of the certificate (optional)</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>A response message containing the certificate</returns>
-        public async Task<CertificateBundle> GetCertificateAsync(string certificateName, string certificateVersion = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<KeyVaultCertificate> GetCertificateAsync(string certificateName, string certificateVersion = null, CancellationToken cancellationToken = default)
         {
             Queue<Exception> exceptions = new Queue<Exception>();
             string vaults = "";
-            certificateVersion = certificateVersion ?? string.Empty;
             foreach (var kv in this._keyVaultClients)
             {
                 try
                 {
-                    return await kv.GetCertificateAsync(kv.VaultUri, certificateName, certificateVersion, cancellationToken).ConfigureAwait(false);
+                    Response<KeyVaultCertificate> response;
+                    if (string.IsNullOrEmpty(certificateVersion))
+                        response = await kv.CertificateClient.GetCertificateAsync(certificateName, cancellationToken).ConfigureAwait(false);
+                    else
+                        response = await kv.CertificateClient.GetCertificateVersionAsync(certificateName, certificateVersion, cancellationToken).ConfigureAwait(false);
+                    return response.Value;
                 }
                 catch (Exception e)
                 {
@@ -489,41 +398,26 @@ namespace Microsoft.Vault.Library
             throw new SecretException($"Failed to get certificate {certificateName} from vault(s){vaults}", exceptions.ToArray());
         }
 
+        /// <summary>
+        ///     Gets the management policy for a certificate from the primary vault.
+        /// </summary>
+        public async Task<CertificatePolicy> GetCertificatePolicyAsync(string certificateName, CancellationToken cancellationToken = default)
+        {
+            var response = await this._keyVaultClients[0].CertificateClient.GetCertificatePolicyAsync(certificateName, cancellationToken).ConfigureAwait(false);
+            return response.Value;
+        }
 
         /// <summary>
         ///     List all certificates from specified vault
-        ///     This function will only look in single specified Azure Key Vault. It will not fallback to other region.
         /// </summary>
-        /// <param name="regionIndex">0 - current region, 1 - other region</param>
-        /// <param name="listCertificatesProgressUpdate">Optional progress update delegate</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>IEnumerable of CertificateItem</returns>
-        public async Task<IEnumerable<CertificateItem>> ListCertificatesAsync(int regionIndex = 0, ListOperationProgressUpdate listCertificatesProgressUpdate = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IEnumerable<CertificateProperties>> ListCertificatesAsync(int regionIndex = 0, ListOperationProgressUpdate listCertificatesProgressUpdate = null, CancellationToken cancellationToken = default)
         {
             Guard.ArgumentIsValidRegion(regionIndex, nameof(regionIndex));
             Guard.ArgumentInRange(regionIndex, 0, this._keyVaultClients.Length - 1, nameof(regionIndex));
-            var listResponse = await this._keyVaultClients[regionIndex].GetCertificatesAsync(this._keyVaultClients[regionIndex].VaultUri, Consts.ListCertificatesMaxResults, cancellationToken: cancellationToken).ConfigureAwait(false);
-            Dictionary<string, CertificateItem> result = new Dictionary<string, CertificateItem>(StringComparer.InvariantCulture);
-            if (listResponse == null) // No certificates in the vault
+            var result = new Dictionary<string, CertificateProperties>(StringComparer.InvariantCulture);
+            await foreach (var cp in this._keyVaultClients[regionIndex].CertificateClient.GetPropertiesOfCertificatesAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
             {
-                return result.Values;
-            }
-
-            foreach (CertificateItem ci in listResponse)
-            {
-                result[ci.Identifier.Name] = ci;
-            }
-
-            listCertificatesProgressUpdate?.Invoke(result.Count);
-
-            while (!string.IsNullOrEmpty(listResponse.NextPageLink))
-            {
-                listResponse = await this._keyVaultClients[regionIndex].GetCertificatesNextAsync(listResponse.NextPageLink, cancellationToken).ConfigureAwait(false);
-                foreach (CertificateItem ci in listResponse)
-                {
-                    result[ci.Identifier.Name] = ci;
-                }
-
+                result[cp.Name] = cp;
                 listCertificatesProgressUpdate?.Invoke(result.Count);
             }
 
@@ -531,21 +425,26 @@ namespace Microsoft.Vault.Library
         }
 
         /// <summary>
-        ///     Imports a new certificate version. If this is the first version, the certificate resource is created.
+        ///     Imports a new certificate version into both vaults.
         /// </summary>
-        /// <param name="certificateName">The name of the certificate</param>
-        /// <param name="certificateCollection">The certificate collection with the private key</param>
-        /// <param name="certificatePolicy">The management policy for the certificate</param>
-        /// <param name="certificateAttributes">The attributes of the certificate (optional)</param>
-        /// <param name="tags">Application-specific metadata in the form of key-value pairs</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>A response message containing the imported certificate.</returns>
-        public async Task<CertificateBundle> ImportCertificateAsync(string certificateName, X509Certificate2Collection certificateCollection, CertificatePolicy certificatePolicy, CertificateAttributes certificateAttributes = null, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<KeyVaultCertificate> ImportCertificateAsync(string certificateName, X509Certificate2Collection certificateCollection, CertificatePolicy certificatePolicy, bool? enabled = null, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
         {
             string thumbprint = certificateCollection.FirstOrDefault()?.Thumbprint.ToLowerInvariant();
             tags = Utils.AddMd5ChangedBy(tags, thumbprint, this.AuthenticatedUserName);
-            var t0 = this._keyVaultClients[0].ImportCertificateAsync(this._keyVaultClients[0].VaultUri, certificateName, certificateCollection, certificatePolicy, certificateAttributes, tags, cancellationToken);
-            var t1 = this.Secondary ? this._keyVaultClients[1].ImportCertificateAsync(this._keyVaultClients[1].VaultUri, certificateName, certificateCollection, certificatePolicy, certificateAttributes, tags, cancellationToken) : CompletedTask;
+
+            byte[] pfxBytes = certificateCollection.Export(X509ContentType.Pkcs12);
+            var options = new ImportCertificateOptions(certificateName, pfxBytes)
+            {
+                Policy = certificatePolicy,
+                Enabled = enabled,
+            };
+            if (tags != null)
+            {
+                foreach (var kvp in tags) options.Tags[kvp.Key] = kvp.Value;
+            }
+
+            var t0 = this._keyVaultClients[0].CertificateClient.ImportCertificateAsync(options, cancellationToken);
+            var t1 = this.Secondary ? this._keyVaultClients[1].CertificateClient.ImportCertificateAsync(options, cancellationToken) : Task.FromResult<Response<KeyVaultCertificate>>(null);
             await Task.WhenAll(t0, t1).ContinueWith(t =>
             {
                 if (t0.IsFaulted && t1.IsFaulted)
@@ -563,20 +462,16 @@ namespace Microsoft.Vault.Library
                     throw new SecretException($"Failed to import certificate {certificateName} to vault {this._keyVaultClients[1]}", t1.Exception);
                 }
             });
-
-            return t0.Result;
+            return t0.Result.Value;
         }
 
         /// <summary>
-        ///     Deletes a certificate from the specified vault.
+        ///     Deletes a certificate from both vaults.
         /// </summary>
-        /// <param name="certificateName">The name of the certificate in the given vault.</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>The deleted certificate</returns>
-        public async Task<CertificateBundle> DeleteCertificateAsync(string certificateName, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task DeleteCertificateAsync(string certificateName, CancellationToken cancellationToken = default)
         {
-            var t0 = this._keyVaultClients[0].DeleteCertificateAsync(this._keyVaultClients[0].VaultUri, certificateName, cancellationToken);
-            var t1 = this.Secondary ? this._keyVaultClients[1].DeleteCertificateAsync(this._keyVaultClients[1].VaultUri, certificateName, cancellationToken) : CompletedTask;
+            var t0 = this._keyVaultClients[0].CertificateClient.StartDeleteCertificateAsync(certificateName, cancellationToken);
+            var t1 = this.Secondary ? this._keyVaultClients[1].CertificateClient.StartDeleteCertificateAsync(certificateName, cancellationToken) : Task.FromResult<DeleteCertificateOperation>(null);
             await Task.WhenAll(t0, t1).ContinueWith(t =>
             {
                 if (t0.IsFaulted && t1.IsFaulted)
@@ -594,26 +489,41 @@ namespace Microsoft.Vault.Library
                     throw new SecretException($"Failed to delete certificate {certificateName} from vault {this._keyVaultClients[1]}", t1.Exception);
                 }
             });
-
-            return t0.Result;
         }
 
         /// <summary>
-        ///     Updates a certificate
+        ///     Updates certificate properties in both vaults.
+        ///     Fetches the current version first so UpdateCertificatePropertiesAsync gets a versioned URI.
         /// </summary>
-        /// <param name="certificateName">The name of the certificate in the given vault.</param>
-        /// <param name="certificateVersion">The certificate version (optional)</param>
-        /// <param name="certificatePolicy">The certificate policy (optional)</param>
-        /// <param name="certificateAttributes">The attributes of the certificate (optional)</param>
-        /// <param name="tags">Application-specific metadata in the form of key-value pairs</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>A response message containing the updated certificate.</returns>
-        public async Task<CertificateBundle> UpdateCertificateAsync(string certificateName, string certificateVersion = null, CertificatePolicy certificatePolicy = null, CertificateAttributes certificateAttributes = null, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<KeyVaultCertificate> UpdateCertificateAsync(string certificateName, string certificateVersion = null, bool? enabled = null, DateTimeOffset? expires = null, DateTimeOffset? notBefore = null, IDictionary<string, string> tags = null, CancellationToken cancellationToken = default)
         {
             tags = Utils.AddMd5ChangedBy(tags, null, this.AuthenticatedUserName);
-            certificateVersion = certificateVersion ?? string.Empty;
-            var t0 = this._keyVaultClients[0].UpdateCertificateAsync(this._keyVaultClients[0].VaultUri, certificateName, certificateVersion, certificatePolicy, certificateAttributes, tags, cancellationToken);
-            var t1 = this.Secondary ? this._keyVaultClients[1].UpdateCertificateAsync(this._keyVaultClients[1].VaultUri, certificateName, certificateVersion, certificatePolicy, certificateAttributes, tags, cancellationToken) : CompletedTask;
+            string version = string.IsNullOrEmpty(certificateVersion) ? null : certificateVersion;
+
+            Response<KeyVaultCertificate> curr0;
+            if (string.IsNullOrEmpty(version))
+                curr0 = await this._keyVaultClients[0].CertificateClient.GetCertificateAsync(certificateName, cancellationToken).ConfigureAwait(false);
+            else
+                curr0 = await this._keyVaultClients[0].CertificateClient.GetCertificateVersionAsync(certificateName, version, cancellationToken).ConfigureAwait(false);
+
+            var props0 = curr0.Value.Properties;
+            ApplyToCertificateProperties(props0, tags, enabled, expires, notBefore);
+            var t0 = this._keyVaultClients[0].CertificateClient.UpdateCertificatePropertiesAsync(props0, cancellationToken);
+
+            Task<Response<KeyVaultCertificate>> t1 = Task.FromResult<Response<KeyVaultCertificate>>(null);
+            if (this.Secondary)
+            {
+                Response<KeyVaultCertificate> curr1;
+                if (string.IsNullOrEmpty(version))
+                    curr1 = await this._keyVaultClients[1].CertificateClient.GetCertificateAsync(certificateName, cancellationToken).ConfigureAwait(false);
+                else
+                    curr1 = await this._keyVaultClients[1].CertificateClient.GetCertificateVersionAsync(certificateName, version, cancellationToken).ConfigureAwait(false);
+
+                var props1 = curr1.Value.Properties;
+                ApplyToCertificateProperties(props1, tags, enabled, expires, notBefore);
+                t1 = this._keyVaultClients[1].CertificateClient.UpdateCertificatePropertiesAsync(props1, cancellationToken);
+            }
+
             await Task.WhenAll(t0, t1).ContinueWith(t =>
             {
                 if (t0.IsFaulted && t1.IsFaulted)
@@ -631,22 +541,28 @@ namespace Microsoft.Vault.Library
                     throw new SecretException($"Failed to update certificate {certificateName} in vault {this._keyVaultClients[1]}", t1.Exception);
                 }
             });
+            return t0.Result.Value;
+        }
 
-            return t0.Result;
+        private static void ApplyToCertificateProperties(CertificateProperties props, IDictionary<string, string> tags, bool? enabled, DateTimeOffset? expires, DateTimeOffset? notBefore)
+        {
+            props.Enabled = enabled;
+            props.ExpiresOn = expires;
+            props.NotBefore = notBefore;
+            props.Tags.Clear();
+            if (tags != null)
+            {
+                foreach (var kvp in tags) props.Tags[kvp.Key] = kvp.Value;
+            }
         }
 
         /// <summary>
-        ///     Updates the policy for a certificate. Set appropriate members in the certificatePolicy that must be updated. Leave
-        ///     others as null.
+        ///     Updates the policy for a certificate in both vaults.
         /// </summary>
-        /// <param name="certificateName">The name of the certificate in the given vault.</param>
-        /// <param name="certificatePolicy">The policy for the certificate.</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>A response message containing the updated certificate policy.</returns>
-        public async Task<CertificatePolicy> UpdateCertificatePolicyAsync(string certificateName, CertificatePolicy certificatePolicy, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<CertificatePolicy> UpdateCertificatePolicyAsync(string certificateName, CertificatePolicy certificatePolicy, CancellationToken cancellationToken = default)
         {
-            var t0 = this._keyVaultClients[0].UpdateCertificatePolicyAsync(this._keyVaultClients[0].VaultUri, certificateName, certificatePolicy, cancellationToken);
-            var t1 = this.Secondary ? this._keyVaultClients[1].UpdateCertificatePolicyAsync(this._keyVaultClients[1].VaultUri, certificateName, certificatePolicy, cancellationToken) : CompletedTask;
+            var t0 = this._keyVaultClients[0].CertificateClient.UpdateCertificatePolicyAsync(certificateName, certificatePolicy, cancellationToken);
+            var t1 = this.Secondary ? this._keyVaultClients[1].CertificateClient.UpdateCertificatePolicyAsync(certificateName, certificatePolicy, cancellationToken) : Task.FromResult<Response<CertificatePolicy>>(null);
             await Task.WhenAll(t0, t1).ContinueWith(t =>
             {
                 if (t0.IsFaulted && t1.IsFaulted)
@@ -664,42 +580,22 @@ namespace Microsoft.Vault.Library
                     throw new SecretException($"Failed to update certificate policy for {certificateName} in vault {this._keyVaultClients[1]}", t1.Exception);
                 }
             });
-
-            return t0.Result;
+            return t0.Result.Value;
         }
 
         /// <summary>
         ///     List the versions of a certificate.
         /// </summary>
-        /// <param name="certificateName">The name of the certificate</param>
-        /// <param name="regionIndex">0 - current region, 1 - other region</param>
-        /// <param name="cancellationToken">Optional cancellation token</param>
-        /// <returns>IEnumerable of CertificateItem</returns>
-        public async Task<IEnumerable<CertificateItem>> GetCertificateVersionsAsync(string certificateName, int regionIndex = 0, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IEnumerable<CertificateProperties>> GetCertificateVersionsAsync(string certificateName, int regionIndex = 0, CancellationToken cancellationToken = default)
         {
             Guard.ArgumentNotNullOrWhitespace(certificateName, nameof(certificateName));
             Guard.ArgumentIsValidRegion(regionIndex, nameof(regionIndex));
             Guard.ArgumentInRange(regionIndex, 0, this._keyVaultClients.Length - 1, nameof(regionIndex));
 
-            var listResponse = await this._keyVaultClients[regionIndex].GetCertificateVersionsAsync(this._keyVaultClients[regionIndex].VaultUri, certificateName, Consts.GetCertificateVersionsMaxResults, cancellationToken: cancellationToken).ConfigureAwait(false);
-            Dictionary<string, CertificateItem> result = new Dictionary<string, CertificateItem>(StringComparer.InvariantCulture);
-            if (listResponse == null) // No certificates in the vault
+            var result = new Dictionary<string, CertificateProperties>(StringComparer.InvariantCulture);
+            await foreach (var cp in this._keyVaultClients[regionIndex].CertificateClient.GetPropertiesOfCertificateVersionsAsync(certificateName, cancellationToken).ConfigureAwait(false))
             {
-                return result.Values;
-            }
-
-            foreach (CertificateItem ci in listResponse)
-            {
-                result[ci.Identifier.Identifier] = ci;
-            }
-
-            while (!string.IsNullOrEmpty(listResponse.NextPageLink))
-            {
-                listResponse = await this._keyVaultClients[regionIndex].GetCertificateVersionsNextAsync(listResponse.NextPageLink, cancellationToken).ConfigureAwait(false);
-                foreach (CertificateItem ci in listResponse)
-                {
-                    result[ci.Identifier.Identifier] = ci;
-                }
+                result[cp.Id.ToString()] = cp;
             }
 
             return result.Values;

--- a/Vault/Library/VaultAccess.cs
+++ b/Vault/Library/VaultAccess.cs
@@ -137,6 +137,8 @@ namespace Microsoft.Vault.Library
             return this._publicClientApp;
         }
 
+        private static bool IsGuid(string value) => Guid.TryParse(value, out _);
+
         protected override async Task<AuthenticationResult> AcquireTokenSilentAsync(string[] scopes, string userAlias = "")
         {
             var app = this.GetPublicClientApp();
@@ -176,6 +178,10 @@ namespace Microsoft.Vault.Library
                 if (userAlias.Contains('@'))
                 {
                     builder = builder.WithLoginHint($"{userAlias}");
+                }
+                else if (IsGuid(this.DomainHint))
+                {
+                    builder = builder.WithLoginHint(userAlias);
                 }
                 else
                 {

--- a/Vault/Library/VaultAccessTokenCredential.cs
+++ b/Vault/Library/VaultAccessTokenCredential.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Vault.Library
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core;
+    using Microsoft.Identity.Client;
+
+    /// <summary>
+    /// Bridges the existing <see cref="VaultAccess"/> MSAL-based auth to the
+    /// <see cref="TokenCredential"/> contract required by Azure SDK Track-2 clients.
+    /// Tries each <see cref="VaultAccess"/> in order, returning the first successful token.
+    /// </summary>
+    internal sealed class VaultAccessTokenCredential : TokenCredential
+    {
+        private readonly VaultAccess[] _vaultAccesses;
+        private readonly string _userAliasType;
+        private readonly string _vaultName;
+        private readonly Action<string> _onAuthenticated;
+
+        internal VaultAccessTokenCredential(VaultAccess[] vaultAccesses, string userAliasType, string vaultName, Action<string> onAuthenticated)
+        {
+            _vaultAccesses = vaultAccesses;
+            _userAliasType = userAliasType ?? string.Empty;
+            _vaultName = vaultName;
+            _onAuthenticated = onAuthenticated;
+        }
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => GetTokenAsync(requestContext, cancellationToken).GetAwaiter().GetResult();
+
+        public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            Queue<Exception> exceptions = new Queue<Exception>();
+            string vaultAccessTypes = "";
+            foreach (VaultAccess va in _vaultAccesses)
+            {
+                try
+                {
+                    AuthenticationResult result = await va.AcquireTokenAsync(requestContext.Scopes, _userAliasType).ConfigureAwait(false);
+                    if (result.Account == null)
+                        throw new VaultAccessException("The authentication result doesn't include account information");
+                    _onAuthenticated?.Invoke(result.Account.Username ?? _userAliasType);
+                    return new AccessToken(result.AccessToken, result.ExpiresOn);
+                }
+                catch (Exception e)
+                {
+                    vaultAccessTypes += $" {va}";
+                    exceptions.Enqueue(e);
+                }
+            }
+            throw new VaultAccessException($"Failed to get access to {_vaultName} with all possible vault access type(s){vaultAccessTypes}", exceptions.ToArray());
+        }
+    }
+}

--- a/Vault/Library/VaultLibrary.csproj
+++ b/Vault/Library/VaultLibrary.csproj
@@ -18,8 +18,8 @@
     <DelaySign>true</DelaySign>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.77.1" />
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.77.1" />
   </ItemGroup>

--- a/Vault/Library/VaultLibrary.csproj
+++ b/Vault/Library/VaultLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Vault.Library</RootNamespace>
     <AssemblyName>Microsoft.Vault.Library</AssemblyName>
@@ -10,6 +10,7 @@
     <StartupObject />
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
   </PropertyGroup>
   <PropertyGroup Condition="Exists('$(DOWNLOADSECUREFILE_SECUREFILEPATH)')">
     <SignAssembly>true</SignAssembly>
@@ -18,9 +19,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.77.1" />
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.77.1" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />

--- a/release.md
+++ b/release.md
@@ -27,7 +27,7 @@
 3. Users install/update from:
 
    ```text
-   https://alta01.github.io/AzureKeyVaultExplorer
+   https://reysic.github.io/AzureKeyVaultExplorer
    ```
 
 ## Manual fallback

--- a/release.md
+++ b/release.md
@@ -1,11 +1,45 @@
-# Release Process
+# Release Process (ClickOnce + GitHub Pages)
 
-## Steps
+## Prerequisites
 
-1. Generate a formatted git tag from the desired state of `main` and push it to GitHub by using the `tag_and_push.ps1` script in the root of this repo:
+1. GitHub Pages is enabled for this repository and publishes from branch `gh-pages`.
+2. The release workflow has `contents: write` permission (configured in `.github/workflows/release.yml`).
+3. Repository has a valid ClickOnce publish profile (`Vault/Explorer/Properties/PublishProfiles/ClickOnceProfile.pubxml`).
+4. For local publishing, use **Visual Studio 2022 17.14+** (MSBuild requirement for .NET 10 ClickOnce).
 
-   ```text
+## Automated release flow
+
+1. Tag the commit you want to release (script helper):
+
+   ```powershell
    .\tag_and_push.ps1
    ```
 
-2. Generate release on GitHub via UI, referencing [tag](https://github.com/reysic/AzureKeyVaultExplorer/tags).
+   This creates and pushes a `v*` tag, which triggers `.github/workflows/release.yml`.
+
+2. Workflow executes `release.ps1`:
+   - restores and publishes VaultExplorer with the ClickOnce profile
+   - uses tag version as `ApplicationVersion`
+   - updates `gh-pages` branch with `Application Files` and `VaultExplorer.application`
+   - initializes `gh-pages` automatically if it does not yet exist
+   - skips commit/push when no deployment content changed
+
+3. Users install/update from:
+
+   ```text
+   https://alta01.github.io/AzureKeyVaultExplorer
+   ```
+
+## Manual fallback
+
+If needed, run locally:
+
+```powershell
+.\release.ps1
+```
+
+Build-only validation (no gh-pages push):
+
+```powershell
+.\release.ps1 -OnlyBuild
+```

--- a/release.ps1
+++ b/release.ps1
@@ -7,6 +7,7 @@ param (
 
 $appName = 'VaultExplorer'
 $projDir = 'Vault\Explorer'
+$installManifest = "$appName.application"
 
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = 'Stop'
@@ -123,8 +124,17 @@ try {
 
     # Copy new application files.
     Write-Output 'Copying new files...'
-    Copy-Item -Path "../$outDir/Application Files", "../$outDir/$appName.application" `
+    Copy-Item -Path "../$outDir/Application Files", "../$outDir/$installManifest" `
         -Destination . -Recurse
+
+    # Ensure GitHub Pages root always points to this fork's current ClickOnce manifest.
+    Set-Content -Path 'index.html' -Encoding UTF8 -Value @"
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to $installManifest</title>
+<meta http-equiv="refresh" content="0; URL=$installManifest">
+<link rel="canonical" href="$installManifest">
+"@
 
     # Stage and commit.
     Write-Output 'Staging...'

--- a/release.ps1
+++ b/release.ps1
@@ -18,7 +18,20 @@ Write-Output "Working directory: $workingDir"
 $msBuildPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
     -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe `
     -prerelease | Select-Object -First 1
+if ([string]::IsNullOrWhiteSpace($msBuildPath)) {
+    throw 'MSBuild was not found. Use the GitHub Actions release workflow on windows-latest.'
+}
+
+$msBuildVersionText = (& $msBuildPath -version -nologo | Select-Object -Last 1).Trim()
 Write-Output "MSBuild: $((Get-Command $msBuildPath).Path)"
+Write-Output "MSBuild version: $msBuildVersionText"
+
+$minimumSupportedVersion = [Version]'17.14.0'
+[Version]$resolvedMsBuildVersion = $null
+if (-not [Version]::TryParse($msBuildVersionText, [ref]$resolvedMsBuildVersion) -or
+    $resolvedMsBuildVersion -lt $minimumSupportedVersion) {
+    throw "MSBuild $minimumSupportedVersion+ is required for .NET 10 ClickOnce publishing. Current: '$msBuildVersionText'. Use GitHub Actions release workflow."
+}
 
 # Load current Git tag.
 $tag = $(git describe --tags)
@@ -40,15 +53,17 @@ Push-Location $projDir
 try {
     Write-Output 'Restoring:'
     dotnet restore -r win-x64
-    Write-Output 'Publishing:'
-    $msBuildVerbosityArg = '/v:m'
-    if ($env:CI) {
-        $msBuildVerbosityArg = ''
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet restore failed with exit code $LASTEXITCODE"
     }
+
+    Write-Output 'Publishing:'
     & $msBuildPath /target:publish /p:PublishProfile=ClickOnceProfile `
         /p:ApplicationVersion=$version /p:Configuration=Release `
-        /p:PublishDir=$publishDir `
-        $msBuildVerbosityArg
+        /p:PublishDir=$publishDir /v:m
+    if ($LASTEXITCODE -ne 0) {
+        throw "MSBuild publish failed with exit code $LASTEXITCODE"
+    }
 
     # Measure publish size.
     $publishSize = (Get-ChildItem -Path "$publishDir/Application Files" -Recurse |
@@ -66,8 +81,37 @@ if ($OnlyBuild) {
 # Clone `gh-pages` branch.
 $ghPagesDir = 'gh-pages'
 if (-Not (Test-Path $ghPagesDir)) {
-    git clone $(git config --get remote.origin.url) -b gh-pages `
-        --depth 1 --single-branch $ghPagesDir
+    $remoteUrl = git config --get remote.origin.url
+    $hasGhPages = $true
+    try {
+        git ls-remote --heads $remoteUrl gh-pages | Out-Null
+        $head = git ls-remote --heads $remoteUrl gh-pages
+        if ([string]::IsNullOrWhiteSpace($head)) {
+            $hasGhPages = $false
+        }
+    }
+    catch {
+        $hasGhPages = $false
+    }
+
+    if ($hasGhPages) {
+        git clone $remoteUrl -b gh-pages --depth 1 --single-branch $ghPagesDir
+    }
+    else {
+        git clone $remoteUrl $ghPagesDir
+        Push-Location $ghPagesDir
+        try {
+            git checkout --orphan gh-pages
+            git rm -rf . | Out-Null
+            Set-Content -Path index.html -Value "<html><body><h1>$appName</h1></body></html>" -Encoding UTF8
+            git add index.html
+            git commit -m "Initialize gh-pages branch"
+            git push origin gh-pages
+        }
+        finally {
+            Pop-Location
+        }
+    }
 }
 
 Push-Location $ghPagesDir
@@ -89,11 +133,15 @@ try {
     # Stage and commit.
     Write-Output 'Staging...'
     git add -A
-    Write-Output 'Committing...'
-    git commit -m "update to v$version"
-
-    # Push.
-    git push
+    $pending = git status --porcelain
+    if ([string]::IsNullOrWhiteSpace($pending)) {
+        Write-Output 'No publish changes detected; skipping commit/push.'
+    }
+    else {
+        Write-Output 'Committing...'
+        git commit -m "update to v$version"
+        git push
+    }
 } finally {
     Pop-Location
 }

--- a/release.ps1
+++ b/release.ps1
@@ -51,15 +51,11 @@ if (Test-Path $outDir) {
 # Publish the application.
 Push-Location $projDir
 try {
-    Write-Output 'Restoring:'
-    dotnet restore -r win-x64
-    if ($LASTEXITCODE -ne 0) {
-        throw "dotnet restore failed with exit code $LASTEXITCODE"
-    }
-
-    Write-Output 'Publishing:'
-    & $msBuildPath /target:publish /p:PublishProfile=ClickOnceProfile `
+    Write-Output 'Restoring + Publishing:'
+    & $msBuildPath /restore /target:publish `
+        /p:RuntimeIdentifier=win-x64 `
         /p:ApplicationVersion=$version /p:Configuration=Release `
+        /p:PublishProfile=ClickOnceProfile `
         /p:PublishDir=$publishDir /v:m
     if ($LASTEXITCODE -ne 0) {
         throw "MSBuild publish failed with exit code $LASTEXITCODE"


### PR DESCRIPTION
## Summary

This PR brings `alta01/AzureKeyVaultExplorer` up to date against `reysic/AzureKeyVaultExplorer:main`, contributing 9 commits (52 files changed, +1738 / −795 lines) across four areas: a .NET 10 migration, Azure SDK Track-2 migration, developer/UX quick wins, and a set of CI/ClickOnce stability fixes.

---

### 1. .NET 10 + CI / ClickOnce Migration

- Upgraded GitHub Actions workflow to .NET SDK 10.0 and `actions/checkout@v4`
- Updated ClickOnce publish profile (`ClickOnceProfile.pubxml`) to target .NET 10 with correct framework/path settings
- Enhanced `release.ps1` to validate MSBuild version and handle .NET 10 ClickOnce publishing edge cases
- Cleaned up `t4.targets` T4 template build process for improved performance
- Pinned `setup-dotnet` SDK in CI to match VS/MSBuild resolver behavior
- Used `MSBuild /restore` publish with `RuntimeIdentifier` so runtime packs resolve correctly in CI
- Updated gh-pages root redirect to point to `VaultExplorer.application` and corrected README install link to the manifest

### 2. Azure SDK Track-2 Migration

Removes three deprecated NuGet packages:
- `Microsoft.Azure.KeyVault` v3.0.5
- `Microsoft.Azure.Management.KeyVault` v3.1.0
- `Microsoft.Rest.ClientRuntime` v2.3.24

Replaces with actively maintained Track-2 packages:
- `Azure.Security.KeyVault.Secrets` v4.7.0
- `Azure.Security.KeyVault.Certificates` v4.7.0
- `Azure.ResourceManager.KeyVault` v1.2.0
- `Azure.Identity` v1.13.0 (for `ArmClient` credential bridge)

New infrastructure files:
- `Vault/Library/ObjectIdentifier.cs` — local Name/Identifier/Version/Vault record
- `Vault/Library/VaultAccessTokenCredential.cs` — MSAL → `TokenCredential` bridge
- `Vault/Explorer/Dialogs/Subscriptions/StaticTokenCredential.cs` — static ARM token
- `Vault/Explorer/Model/Files/Secrets/SecretFileData.cs` — JSON-serializable secret DTO
- `Vault/Explorer/Model/Files/Secrets/CertificateFileData.cs` — JSON-serializable cert DTO

Key changes:
- `VaultKeyValueClient` replaces `KeyVaultClientEx`; holds `SecretClient` + `CertificateClient`
- `Vault.cs`: all methods updated for new SDK types and `AsyncPageable` iteration
- `GetCertificatePolicyAsync` added (policy no longer embedded in `GetCertificateAsync`)
- Management plane: `ArmClient` + `StaticTokenCredential` replaces `KeyVaultManagementClient`
- All model/dialog/list files updated for `SecretProperties`, `CertificateProperties`, `KeyVaultSecret`, `KeyVaultCertificate`, `CertificatePolicy` flat-structure types
- `RequestFailedException` replaces `CloudException`/`KeyVaultErrorException`
- `CertificatePolicyAction` replaces `ActionType` enum in lifetime actions
- Follow-up fix: replaced invalid `string[]` cast in `AccessPolicyEntryItem` with correctly typed `Array.Empty<T>()` calls

### 3. Developer Workflow & UX Quick Wins

New copy formats in the Share toolbar dropdown and right-click context menu:
- **D1** Copy as env var (`NAME=value`)
- **D2** Copy as Docker `--env`
- **D3** Copy as Kubernetes Secret YAML
- **D4** Copy name only (`Ctrl+Shift+N`)

UX improvements:
- **U2** Last-used vault alias remembered across sessions (`LastUsedVaultAlias` setting), restored on startup
- **U3+U6** Status bar shows vault alias prefix and expiring-secret count; window title gains `| N expiring` badge
- **U4** Show/Hide toggle in `SecretDialog` masks value with asterisks; `TextChanged` handler guarded to avoid corrupting `PropertyObject.Value`
- **U5** "Expires" list column renamed to "Expires in" to match the relative-time format already produced by `Utils.ExpirationToString`

### 4. ClickOnce / Auth / Onboarding Fixes

- Ignore non-vault activation URLs at startup; update fork activation constants
- Show tenant display name alongside tenant ID in the tenant selector
- Defer onboarding `MessageBox` to the `Shown` event so the form renders before any prompt appears
- Wrap `Vaults.GetAsync` in try/catch so a failed vault detail fetch shows a clear error without crashing or permanently disabling the OK button
- Add `MinimumSize` to `SubscriptionsManagerDialog` to prevent button clipping on resize
- Restore tenant selection in subscription flow, re-auth on tenant change, and block saving vault config without a signed-in account context

### Other

- Added `AGENTS.md` documenting project layout, conventions, and key files
- Re-pointed all GitHub/Pages URLs from `alta01` to `reysic` across `Globals.cs`, `ClickOnceProfile.pubxml`, `README.md`, and `release.md`
- Refactored certificate loading in `CertificateDialog` and `CertificateValueObject` to use `X509CertificateLoader`
